### PR TITLE
fix: Changed defaultBinariesPath to match install.sh path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,5 +58,5 @@ func persistentPreRun(cmd *cobra.Command, args []string) {
 
 func defaultBinariesPath() string {
 	home, _ := os.UserHomeDir() // sue me
-	return path.Join(home, "privateer", "bin")
+	return path.Join(home, ".privateer", "bin")
 }


### PR DESCRIPTION
currently privateer installs to `~/.privateer/bin` but the default directory for raids is `~/privateer/bin`.