### PR TITLE
fix: add generated generated-raids folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage.out
 dist/
 
 test_output
+
+**/generated-raid


### PR DESCRIPTION
So no one accidentally source controls them