### PR TITLE
chore: Don't list privateer binary when listing plugins

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	hcplugin "github.com/hashicorp/go-plugin"
 	"github.com/spf13/cobra"
@@ -63,6 +64,9 @@ func getAvailableRaids() (availableRaidPackages []*RaidPkg) {
 	for _, raidPath := range raidPaths {
 		raidPkg := NewRaidPkg(path.Base(raidPath), "")
 		raidPkg.Available = true
+		if strings.Contains(raidPkg.Name,  "privateer"){
+			continue
+		}
 		availableRaidPackages = append(availableRaidPackages, raidPkg)
 	}
 	return availableRaidPackages


### PR DESCRIPTION
When the privateer binary list command is executed, do not show the privateer binary.