### PR TITLE
chore: added security insights file

### DIFF
--- a/.github/security-insights.yml
+++ b/.github/security-insights.yml
@@ -1,0 +1,67 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2021-09-01'
+  last-reviewed: '2022-09-01'
+  url: https://github.com/privateerproj/privateer/blob/main/.github/security-insights.yml
+  project-si-source: https://github.com/privateerproj/.github/blob/main/.github/security-insights.yml
+  comment: |
+    This file contains only the repository information for the core Privateer CLI.
+
+repository:
+  url: https://github.com/privateerproj/privateer
+  status: active
+  bug-fixes-only: false
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name:        Eddie Knight
+      affiliation: Sonatype
+      social:      https://bsky.app/profile/eddieknight.dev
+      primary:     true
+    - name:        Jason Meridth
+      affiliation: GitHub
+      primary:     false
+    - name:        Rudra Gupta
+      affiliation: Krumware
+      primary:     false
+  documentation:
+    contributing-guide: https://github.com/privateerproj/.github/blob/main/.github/CONTRIBUTING.md
+    security-policy: https://github.com/privateerproj/.github/blob/main/.github/SECURITY.md
+  license:
+    url: n/a
+    expression: n/a
+  release:
+    changelog: https://github.com/privateerproj/privateer/releases
+    automated-pipeline: true
+    distribution-points:
+      - uri:  https://github.com/privateerproj/privateer/releases
+        comment: GitHub Release Page
+    license:
+      url: https://foo.bar/release/{version}#license
+      expression: MIT AND Apache-2.0
+  security:
+    assessments:
+      self:
+        comment: |
+          A self assessment has not been published for this repo.
+    champions:
+      - name:   Jason Meridth
+        primary: true
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: 2
+        rulesets:
+          - built-in
+        results:
+          adhoc:
+            name: Scheduled SCA Scan Results
+            predicate-uri: https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
+            location: https://github.com/privateerproj/privateer/security/dependabot
+            comment: |
+              The results of the scheduled SCA scan are available in the Dependabot tab of the Security Insights page.
+        integration:
+          adhoc: true
+          ci: false
+          release: false


### PR DESCRIPTION
this SI file contains only repo information, and pulls project info from https://github.com/privateerproj/privateer/blob/main/.github/security-insights.yml

cc/ @grudra7714 and @jmeridth I've included you both in the `Core Team` list for this repo