### PR TITLE
fix: goreleaser stuff

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
         with:
           distribution: goreleaser
-          version: ${{ github.ref_name }}
+          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,33 +1,19 @@
-name: goreleaser
-
+---
+name: "Goreleaser"
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "*"
-
-permissions:
-  contents: write
-
+  release:
+    types: [published]
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      ## After having trouble with the PUBLISHER_TOKEN, I started down this path...
-      ## But I never got the APP_ID to be accepted by the action
-      ## Error: [@octokit/auth-app] appId option must be a number or numeric string
-      # - name: Generate token
-      #   id: generate_token
-      #   uses: tibdex/github-app-token@v1
-      #   with:
-      #     app_id: ${{ secrets.APP_ID }}
-      #     private_key: ${{ secrets.APP_PEM }}
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Fetch all tags
-        run: git fetch --force --tags
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -36,7 +22,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,19 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
-  - binary: privateer
-    env:
+  - env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -14,7 +22,7 @@ builds:
 
 archives:
   - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
+    # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -24,25 +32,18 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
-    - goos: windows
-      format: zip
-checksum:
-  name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+      - goos: windows
+        format: zip
+
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
+
 release:
   prerelease: auto
 
 universal_binaries:
   - replace: true
-
-# The lines beneath this are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
Fixes #12

- [x] rebuild .goreleaser.yml from scratch to meet new version (goreleaser init)
  - copy over pieces we need from old config
  - verified good with `goreleaser check`
- [x] change goreleaser github action to fire on newly published releases, not new tags

Our new release github action will create the release and do all the templating based on conventional commits pr titles and auto-labelling.  Now goreleaser will see the newly published release and attach the new asset builds to the new release.

Was tested in https://github.com/jmeridth/test-reusable-release-with-goreleaser