### PR TITLE
chore: add Dockerfile to build release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.23.4-alpine3.21 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN apk add --no-cache make git && \
+  go mod tidy && \
+  make go-build
+
+FROM alpine:3.21
+
+WORKDIR /app
+
+COPY --from=build /app/privateer /app/privateer
+
+CMD ["/app/privateer", "--help"]


### PR DESCRIPTION
To test locally:

build the image:

```bash
docker build . --tag privateer:0.2.0
```

run a temporary image, passing in the config file from local:

```bash
docker run -it --rm --name debug -v ./config.yml:/app/config.yml privateer:0.2.0
```

currently only displays help command

image is currently 32.7MB