### PR TITLE
docs: update how-to-generate-example-plugin.md with missing parts

### DIFF
--- a/docs/how-to-generate-example-plugin.md
+++ b/docs/how-to-generate-example-plugin.md
@@ -9,6 +9,9 @@ This guide allows you to not have to start from scratch on a new plugin.
 
 - get [`CCC.VPC_2025.01.yaml`](https://github.com/finos/common-cloud-controls/releases/download/v2025.01.VPC-rc/CCC.VPC_2025.01.yaml) file from [Common Cloud Controls Repository Releases page](https://github.com/finos/common-cloud-controls/releases)
 
+> [!WARNING]
+> Currently the `CCC.VPC_2024.01.yaml` file has duplicate entries of the `CCC.C04.TR01` test requirement.  One needs to be removed before being used.  Removing lines 198-204 of the file will fix the issue.
+
 > [!NOTE]
 > Version may change or you may need to expand the `Assets` section to find the latest yaml file.
 
@@ -50,6 +53,7 @@ This guide allows you to not have to start from scratch on a new plugin.
 
     ```bash
     cp example $HOME/.privateer/bin
+    cp config.yml ../
     cd ..
     privateer run
     ```


### PR DESCRIPTION
- [x] mention the duplicate test requirement `CCC.C04.TR01` in the `CCC.VPC_2025.01.yaml` file (to be used to generate the plugin)
- [x] mention copying the config used to run the example plugin up to the privateer binary (root of repo) before running `privateer run`