### PR TITLE
chore: auto-labeler workflow perms and goreleaser config

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   auto_labeler:
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@6a0a6d0de2227f9d5d11af90a87b2e2fd6b5463d
     with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,7 +21,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -33,7 +33,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 changelog:
   sort: asc


### PR DESCRIPTION
- [x] change contents: write to read for auto-labeler workflow
- [x] update goreleaser config due to deprecations
  - https://github.com/privateerproj/privateer/actions/runs/12999165564/job/36253914307#step:4:23-23