### PR TITLE
chore: updated to use latest SCI in the generator

### DIFF
--- a/cmd/generate-plugin.go
+++ b/cmd/generate-plugin.go
@@ -128,9 +128,13 @@ func generateFileFromTemplate(data CatalogData, templatePath, OutputDir string) 
 	}
 
 	tmpl, err := template.New("plugin").Funcs(template.FuncMap{
-		"prettify": func(s string) string {
-			return strings.TrimSpace(strings.ReplaceAll(
-				strings.ReplaceAll(s, "\n", " "), ".", "_"))
+		"clean_spaces": func(s string) string {
+			return strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+		},
+		"as_id": func(s string) string {
+			return strings.TrimSpace(
+				strings.ReplaceAll(
+					strings.ReplaceAll(s, ".", "_"), "-", "_"))
 		},
 	}).Parse(string(templateContent))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/privateerproj/privateer-sdk v0.6.1
-	github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250223164144-5fad3b3dc290
+	github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250226143903-507084ca3f87
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privateerproj/privateer-sdk v0.6.1 h1:uXojv/E61ETiuAU9SWprJcINA4lgV3bXK7YF/53cd68=
 github.com/privateerproj/privateer-sdk v0.6.1/go.mod h1:2utlXAO2fAOFgXKLjn/t6UqkU/4MpEYy2hLxacUsIMs=
-github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250223164144-5fad3b3dc290 h1:F6fpBIr4ACgJm6+MOav08LFvsHbH6Xub1a4JS4VgR34=
-github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250223164144-5fad3b3dc290/go.mod h1:+Qqc7Q6ODGeeEqc7hNCEzJ5XtVpG+Lt6FqOamEx8MNU=
+github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250226143903-507084ca3f87 h1:9s9BMQNTE/x45TUIrqiqO8lS7ZzeN3zlN9WP4PrO3U0=
+github.com/revanite-io/sci/pkg/layer2 v0.0.0-20250226143903-507084ca3f87/go.mod h1:+Qqc7Q6ODGeeEqc7hNCEzJ5XtVpG+Lt6FqOamEx8MNU=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
I'm not sure why this still isn't getting SCI by version number, but it seems to be working to pull main, which is all we need for now.