### PR TITLE
fix: update Dependabot labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # All PRs in this repository will be blocked until they
 # have been approved by the respective code owner
 
-* @privateerproj/oss-maintainers
+* @privateerproj/oss

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: []
     groups:
       dependencies:
         applies-to: version-updates
@@ -19,6 +20,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: []
     groups:
       dependencies:
         applies-to: version-updates


### PR DESCRIPTION
Update dependabot to not add labels to its PRs. It is colliding with our auto labeller and releases when `major`, `minor`, or `patch` labels are auto added to Dependabot PRs by Dependabot