### PR TITLE
fix: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23.4
+          go-version: 1.24
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:


### PR DESCRIPTION
Update to go 1.24 to get go-releaser workflow working. 

[Failure](https://github.com/privateerproj/privateer/actions/runs/18017618048/job/51266531341#step:4:1)