### PR TITLE
chore: get go version file for workflows from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1.23.4"
+          go-version-file: go.mod
 
       - name: Setup GO environment
         run: |
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1.23.4"
+          go-version-file: go.mod
       - name: Build
         run: make -B build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:


### PR DESCRIPTION
Goreleaser will fail if we do not use the version we use in `go.mod` this solution is the best in case we upgrade the version in `go.mod` again and forget to update the workflow or Dependabot misses it to.

[Docs](https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file)