### PR TITLE
feat: Use SDK run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,10 +29,6 @@ When everything is battoned down, it is time to run forth.`,
 	},
 }
 
-// Re-export exit codes from SDK for backwards compatibility
-const (
-)
-
 func init() {
 	rootCmd.AddCommand(runCmd)
 }


### PR DESCRIPTION
## Use SDK run command

Removes duplicate run command logic and uses SDK implementation instead.

## Changes
- Replace `Run()` implementation with `command.Run(logger, GetPlugins)`
- Remove `closeClient()`, `newClient()` helper functions (moved to SDK)
- Keep `setupCloseHandler()` for SIGTERM handling (process exits)
- Re-export exit codes from SDK for backwards compatibility

## Dependencies
**Depends on**: 
- privateerproj/privateer-sdk#127 (types PR)
- privateerproj/privateer-sdk#128 (list PR)  
- privateerproj/privateer-sdk#129 (run PR) - Must be merged first

