### PR TITLE
fix: Use correct action repo reference 

### DIFF
--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSPS Security Assessment
-        uses: revanite-io/pvtr-github-repo-action@main
+        uses: revanite-io/pvtr-github-repo-action@54aac6d5420f6a2aef63fce273c027f1a36d4678
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
Fixes the workflow error where it was trying to use commit SHA `82a32714f8122e90746dad06d9d3b86ce9764e56` from the wrong repo (`pvtr-github-repo` instead of `pvtr-github-repo-action`).

Changes:
- Changed from: `revanite-io/pvtr-github-repo-action@82a32714f8122e90746dad06d9d3b86ce9764e56` (wrong commit SHA from wrong repo)
- Changed to: `revanite-io/pvtr-github-repo-action@main` (correct - uses main branch of action repo)

This fixes the error: `An action could not be found at the URI`