### PR TITLE
fix: Use PAT instead of GITHUB_TOKEN for org repo permissions

### DIFF
--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PRIVATEER_GITHUB_TOKEN }}
           catalog: "osps-baseline"
           upload-sarif: "true"
 


### PR DESCRIPTION
Fixes the "Resource not accessible by integration" error when querying GitHub GraphQL API in organization repos.

The plugin requires organization-level permissions (admin:org) to fetch org metadata which GITHUB_TOKEN doesn't have in org repos by default.

Changes:
- Changed from: `secrets.GITHUB_TOKEN`
- Changed to: `secrets.PRIVATEER_GITHUB_TOKEN`

**Note:** A repository secret named `PRIVATEER_GITHUB_TOKEN` needs to be added with a PAT that has `repo` and `admin:org` permissions.