### PR TITLE
fix: install script part deux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ download_latest_release() {
     echo "Downloading from: $url"
 
     # Download the binary to the specified install directory
-    curl -L -o "$install_file" "$url"
+    curl -L -0 "$url" | tar xvf - -C "$install_dir"
 
     if [[ $? -ne 0 ]]; then
         echo "Failed to download the binary."


### PR DESCRIPTION
Fixes https://github.com/privateerproj/privateer/issues/163

We assumed the tar.gz file only has the `privateer` binary in it. It has LICENSE and README files also, so exporting that all into the ~/.privateer/bin directory as a single binary doesn't work.

This exports everything into the ~/.privateer/bin directory.

I know the tar command can be picky between Linux and Darwin. I've confirmed on Darwin.

Future solutions could include not having the LICENSE and README in the release tar.gz.