### PR TITLE
fix: stop creating log directories for non-run commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/privateerproj/privateer-sdk/command"
-	"github.com/privateerproj/privateer-sdk/config"
 )
 
 var (
@@ -63,11 +62,17 @@ func init() {
 }
 
 // persistentPreRun initializes the logger and writer for use by all commands.
-// It is called before every command execution and sets up the configuration
-// and output formatting utilities.
+// It is called before every command execution and sets up lightweight logging
+// that does not create files or directories on disk.
 func persistentPreRun(cmd *cobra.Command, args []string) {
-	cfg := config.NewConfig(nil)
-	logger = cfg.Logger
+	loglevel := viper.GetString("loglevel")
+	if loglevel == "" {
+		loglevel = "error"
+	}
+	logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.LevelFromString(loglevel),
+		Output: os.Stderr,
+	})
 
 	// writer is used for output in the list & version commands
 	writer = tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/privateerproj/privateer-sdk/command"
+	"github.com/privateerproj/privateer-sdk/config"
 )
 
 // runCmd represents the run command, which executes all plugins specified in the configuration.
@@ -42,6 +43,11 @@ func init() {
 func Run() (exitCode int) {
 	// Setup for handling SIGTERM (Ctrl+C)
 	setupCloseHandler()
+
+	// Initialize full config here so file-backed logging is only
+	// created when actually running plugins, not for every command.
+	cfg := config.NewConfig(nil)
+	logger = cfg.Logger
 
 	return command.Run(logger, command.GetPlugins)
 }


### PR DESCRIPTION
Closes https://github.com/privateerproj/privateer/issues/170

## What

Moved config.NewConfig initialization from persistentPreRun into the run command. The persistent pre-run now creates a lightweight hclog logger that writes to stderr without touching the filesystem.

## Why

Every command, including `privateer version`, was calling config.NewConfig which triggers SetupLogging with file writing enabled by default. This created an `evaluation_results` directory and `overview.log` file on disk even when no plugins were being executed.

## Notes

- Commands like `version`, `list`, and `generate-plugin` still get a functional logger via the lightweight hclog instance — just without file-backed logging
- The `generate-plugin` command uses the package-level logger for error reporting; this still works since the lightweight logger is initialized in persistentPreRun before any subcommand runs
- The full config is now initialized after setupCloseHandler in Run(), so the signal handler briefly references the lightweight logger before it gets upgraded — this is fine since the config init is synchronous

## Proof

<details><summary>Before</summary>
<p>

- show no `evaluation_results` folder BEFORE running privateer
- show `evaluation_results` folder AFTER running privateer (needs fixing)

```bash
➜  .privateer> ls -lah
total 8
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 17:14 .
drwxr-x---+ 53 jmeridth  staff   1.7K Feb 14 17:14 ..
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 09:13 bin
-rw-r--r--@  1 jmeridth  staff   1.1K Feb 14 09:45 config.yml
➜  .privateer> ./bin/privateer list
| Plugin        | Requested  |
| github-repo   | true       |
➜  .privateer> ls -lah
total 8
drwxr-xr-x@  5 jmeridth  staff   160B Feb 14 17:14 .
drwxr-x---+ 53 jmeridth  staff   1.7K Feb 14 17:14 ..
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 09:13 bin
-rw-r--r--@  1 jmeridth  staff   1.1K Feb 14 09:45 config.yml
drwxr-xr-x@  3 jmeridth  staff    96B Feb 14 17:14 evaluation_results
➜  .privateer> cat evaluation_results/overview.log
```

</p>
</details> 

<details><summary>After</summary>
<p>

- show no `evaluation_results` folder BEFORE running privateer
- show no `evaluation_results` folder AFTER running privateer (fixed)

```bash
➜  .privateer> ls -lah
total 8
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 17:18 .
drwxr-x---+ 53 jmeridth  staff   1.7K Feb 14 17:18 ..
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 09:13 bin
-rw-r--r--@  1 jmeridth  staff   1.1K Feb 14 09:45 config.yml
➜  .privateer> ./bin/privateer list
| Plugin        | Requested  |
| github-repo   | true       |
➜  .privateer> ls -lah
total 8
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 17:18 .
drwxr-x---+ 53 jmeridth  staff   1.7K Feb 14 17:18 ..
drwxr-xr-x@  4 jmeridth  staff   128B Feb 14 09:13 bin
-rw-r--r--@  1 jmeridth  staff   1.1K Feb 14 09:45 config.yml
```

</p>
</details> 