### PR TITLE
refactor: simplify acceptance test error handling

### DIFF
--- a/build/github/acceptance_test.sh
+++ b/build/github/acceptance_test.sh
@@ -4,36 +4,11 @@ set -x
 
 STATUS=0
 
-./privateer completion
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
-
-./privateer generate-plugin -p ./test/data/CCC.VPC_2025.01.yaml -n example
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
-
-./privateer help
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
-
-./privateer list
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
-
-./privateer run -b ./test/data/
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
-
-./privateer version
-if [ $? -ne 0 ]; then
-    STATUS=1
-fi
+./privateer completion || STATUS=1
+./privateer generate-plugin -p ./test/data/CCC.VPC_2025.01.yaml -n example || STATUS=1
+./privateer help || STATUS=1
+./privateer list || STATUS=1
+./privateer run -b ./test/data/ || STATUS=1
+./privateer version || STATUS=1
 
 exit $STATUS
-
-


### PR DESCRIPTION
## What

Replace verbose if/then blocks with idiomatic shell || operator for tracking command failures in the acceptance test script.

## Why

The repeated $? check pattern is unnecessarily verbose. The || idiom is the standard shell approach for "run but record failure" and reduces the script from 40 lines to 14 with identical behavior.

## Notes

- No behavioral change — all commands still run regardless of earlier failures, and the aggregate exit status is preserved