### PR TITLE
fix: inject version info into binaries via goreleaser ldflags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,12 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.VersionPostfix=
+      - -X main.GitCommitHash={{.Commit}}
+      - -X main.BuiltAt={{.Date}}
 
 archives:
   - formats: ["tar.gz"]


### PR DESCRIPTION
## What

Add ldflags to the goreleaser build config to set Version, VersionPostfix, GitCommitHash, and BuiltAt at build time.

## Why

Released binaries report "0.0.0-dev" because the default values in main.go are never overridden during the goreleaser build. Without ldflags, the Go linker has no instruction to replace them.

## Notes

- VersionPostfix is explicitly set to empty string to prevent the fmt.Sprintf("%s-%s", Version, VersionPostfix) branch from appending "-dev" to the tag-derived version
- `-s -w` strips debug info and DWARF symbols, reducing binary size but making stack traces less detailed if users report panics
- Existing releases are unaffected; only future tags will pick this up