### PR TITLE
feat: add env command to display runtime environment info

### DIFF
--- a/build/github/acceptance_test.sh
+++ b/build/github/acceptance_test.sh
@@ -5,6 +5,7 @@ set -x
 STATUS=0
 
 ./privateer completion || STATUS=1
+./privateer env || STATUS=1
 ./privateer generate-plugin -p ./test/data/CCC.VPC_2025.01.yaml -n example || STATUS=1
 ./privateer help || STATUS=1
 ./privateer list || STATUS=1

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	hcplugin "github.com/hashicorp/go-plugin"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// envCmd represents the env command, which displays runtime environment details.
+var envCmd = &cobra.Command{
+	Use:     "env",
+	Aliases: []string{"info"},
+	Short:   "Display runtime environment details.",
+	Long:    `Display the binary path, config location, plugins directory, installed plugins, version, and build information.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		binaryPath, err := os.Executable()
+		if err != nil {
+			binaryPath = "unknown"
+		}
+
+		configFile := viper.ConfigFileUsed()
+		var configStatus string
+		if configFile == "" {
+			configStatus = "none"
+		} else if _, err := os.Stat(configFile); err == nil {
+			configStatus = fmt.Sprintf("%s (found)", configFile)
+		} else {
+			configStatus = fmt.Sprintf("%s (not found)", configFile)
+		}
+
+		pluginsDir := viper.GetString("binaries-path")
+		pluginNames := discoverPluginNames(pluginsDir)
+
+		_, _ = fmt.Fprintf(writer, "Binary:\t%s\n", binaryPath)
+		_, _ = fmt.Fprintf(writer, "Config:\t%s\n", configStatus)
+		_, _ = fmt.Fprintf(writer, "Plugins Dir:\t%s\n", pluginsDir)
+		_, _ = fmt.Fprintf(writer, "Plugins:\t%s\n", pluginNames)
+		_, _ = fmt.Fprintf(writer, "Version:\t%s\n", buildVersion)
+		_, _ = fmt.Fprintf(writer, "Commit:\t%s\n", buildGitCommitHash)
+		_, _ = fmt.Fprintf(writer, "Build Time:\t%s\n", buildTime)
+		_, _ = fmt.Fprintf(writer, "Go Version:\t%s\n", runtime.Version())
+		_, _ = fmt.Fprintf(writer, "OS/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+		if err := writer.Flush(); err != nil {
+			log.Printf("Error flushing writer: %v", err)
+		}
+	},
+}
+
+func discoverPluginNames(pluginsDir string) string {
+	pluginPaths, _ := hcplugin.Discover("*", pluginsDir)
+	var names []string
+	for _, p := range pluginPaths {
+		name := filepath.Base(p)
+		if strings.Contains(name, "privateer") {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return "none"
+	}
+	return strings.Join(names, ", ")
+}
+
+func init() {
+	rootCmd.AddCommand(envCmd)
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"text/tabwriter"
+)
+
+func TestEnvCmd_ContainsExpectedFields(t *testing.T) {
+	var buf bytes.Buffer
+	writer = tabwriter.NewWriter(&buf, 1, 1, 1, ' ', 0)
+
+	buildVersion = "1.2.3"
+	buildGitCommitHash = "a1b2c3d"
+	buildTime = "2026-01-01T00:00:00Z"
+
+	envCmd.Run(envCmd, []string{})
+
+	output := buf.String()
+
+	expectedFields := []string{
+		"Binary:",
+		"Config:",
+		"Plugins Dir:",
+		"Plugins:",
+		"Version:",
+		"Commit:",
+		"Build Time:",
+		"Go Version:",
+		"OS/Arch:",
+	}
+	for _, field := range expectedFields {
+		if !strings.Contains(output, field) {
+			t.Errorf("expected output to contain %q, got:\n%s", field, output)
+		}
+	}
+}
+
+func TestEnvCmd_DisplaysBuildInfo(t *testing.T) {
+	var buf bytes.Buffer
+	writer = tabwriter.NewWriter(&buf, 1, 1, 1, ' ', 0)
+
+	buildVersion = "test-version"
+	buildGitCommitHash = "e4f5a6b"
+	buildTime = "2026-02-15T00:00:00Z"
+
+	envCmd.Run(envCmd, []string{})
+
+	output := buf.String()
+
+	if !strings.Contains(output, "test-version") {
+		t.Errorf("expected output to contain version 'test-version', got:\n%s", output)
+	}
+	if !strings.Contains(output, "e4f5a6b") {
+		t.Errorf("expected output to contain commit 'e4f5a6b', got:\n%s", output)
+	}
+	if !strings.Contains(output, "2026-02-15T00:00:00Z") {
+		t.Errorf("expected output to contain build time, got:\n%s", output)
+	}
+	if !strings.Contains(output, runtime.Version()) {
+		t.Errorf("expected output to contain Go version %q, got:\n%s", runtime.Version(), output)
+	}
+	expectedArch := runtime.GOOS + "/" + runtime.GOARCH
+	if !strings.Contains(output, expectedArch) {
+		t.Errorf("expected output to contain OS/Arch %q, got:\n%s", expectedArch, output)
+	}
+}
+
+func TestEnvCmd_ShowsBinaryPath(t *testing.T) {
+	var buf bytes.Buffer
+	writer = tabwriter.NewWriter(&buf, 1, 1, 1, ' ', 0)
+
+	envCmd.Run(envCmd, []string{})
+
+	output := buf.String()
+
+	execPath, err := os.Executable()
+	if err == nil && !strings.Contains(output, execPath) {
+		t.Errorf("expected output to contain executable path %q, got:\n%s", execPath, output)
+	}
+}
+
+func TestDiscoverPluginNames_EmptyDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "privateer-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	result := discoverPluginNames(tmpDir)
+	if result != "none" {
+		t.Errorf("expected 'none' for empty dir, got: %s", result)
+	}
+}
+
+func TestDiscoverPluginNames_NonexistentDir(t *testing.T) {
+	result := discoverPluginNames("/nonexistent/path")
+	if result != "none" {
+		t.Errorf("expected 'none' for nonexistent dir, got: %s", result)
+	}
+}
+
+func TestDiscoverPluginNames_FiltersPrivateer(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "privateer-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	for _, name := range []string{"privateer", "privateer-foo", "my-plugin", "other-tool"} {
+		path := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
+			t.Fatalf("failed to create file %s: %v", name, err)
+		}
+	}
+
+	result := discoverPluginNames(tmpDir)
+
+	if strings.Contains(result, "privateer") {
+		t.Errorf("expected privateer binaries to be filtered out, got: %s", result)
+	}
+	if !strings.Contains(result, "my-plugin") {
+		t.Errorf("expected 'my-plugin' in result, got: %s", result)
+	}
+	if !strings.Contains(result, "other-tool") {
+		t.Errorf("expected 'other-tool' in result, got: %s", result)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/privateerproj/privateer/issues/181

## What

Add a new `env` command (aliased as `info`) that displays the binary path, config location, plugins directory, discovered plugins, version, commit, build time, Go version, and OS/arch.

## Why

There was no way to quickly see which privateer binary is running or where it's looking for config and plugins, making troubleshooting harder than necessary.

## Notes

- The `env` command overlaps with `version --verbose` for build info fields; this is intentional as they serve different purposes
- Plugin discovery reuses the same hashicorp/go-plugin Discover call as the list command but filters out privateer binaries, matching existing behavior in the SDK
- Config path comes from viper's "config" key which defaults to {cwd}/config.yml via the SDK's SetBase