### PR TITLE
feat: add pvtr-github-repo plugin integration test

### DIFF
--- a/.github/chainguard/privateer.sts.yaml
+++ b/.github/chainguard/privateer.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:privateerproj/privateer:(pull_request|ref:refs/heads/main)"
+claim_pattern:
+  job_workflow_ref: "^privateerproj/privateer/.github/workflows/ci.yml@refs/(heads/main|pull/[0-9]+/merge)$"
+
+permissions:
+  contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,36 @@ jobs:
 
       - name: Acceptance tests
         run: ./build/github/acceptance_test.sh
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: make -B build
+
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05
+        id: octo-sts
+        with:
+          scope: privateerproj/privateer
+          identity: privateer
+
+      - name: GitHub Repo Plugin Integration Test
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          set -o pipefail
+          ./build/github/github_repo_plugin_test.sh 2>&1 | tee integration_output.txt
+
+      - name: Verify integration test output
+        run: |
+          grep -E 'privateer_osps-baseline.*Passed.*Warnings.*Failed.*Possible' integration_output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ config*
 
 # Test
 coverage.out
+test_config.yml
+test_plugins/
 
 # OS
 .DS_Store

--- a/build/github/github_repo_plugin_test.sh
+++ b/build/github/github_repo_plugin_test.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -x
+
+STATUS=0
+
+# Require gh CLI to be installed
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is not installed"
+  echo "Install it from https://cli.github.com/"
+  exit 1
+fi
+
+# Require GITHUB_TOKEN to be set
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "ERROR: GITHUB_TOKEN environment variable is not set"
+  echo "You can do the following to set it:"
+  echo "  \`gh auth login\` and follow the prompts to authenticate with GitHub"
+  echo "  export GITHUB_TOKEN=\$(gh auth token)"
+  exit 1
+fi
+
+# Detect OS and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Linux)  RELEASE_OS="Linux" ;;
+  Darwin) RELEASE_OS="Darwin" ;;
+  *)
+    echo "ERROR: Unsupported OS: $OS"
+    exit 1
+    ;;
+esac
+
+case "$ARCH" in
+  x86_64)  RELEASE_ARCH="x86_64" ;;
+  aarch64) RELEASE_ARCH="arm64" ;;
+  arm64)   RELEASE_ARCH="arm64" ;;
+  i386)    RELEASE_ARCH="i386" ;;
+  i686)    RELEASE_ARCH="i386" ;;
+  *)
+    echo "ERROR: Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+# Darwin releases use "all" for architecture
+if [ "$RELEASE_OS" = "Darwin" ]; then
+  RELEASE_ARCH="all"
+fi
+
+ASSET_PATTERN="pvtr-github-repo_${RELEASE_OS}_${RELEASE_ARCH}.tar.gz"
+PLUGIN_DIR="./test_plugins"
+CONFIG_FILE="./test_config.yml"
+
+# Ensure cleanup happens even on unexpected exits or signals
+trap 'rm -rf "$PLUGIN_DIR" "$CONFIG_FILE" "/tmp/$ASSET_PATTERN" evaluation_results' EXIT
+
+# Download latest pvtr-github-repo release
+mkdir -p "$PLUGIN_DIR"
+gh release download \
+  --repo revanite-io/pvtr-github-repo \
+  --pattern "$ASSET_PATTERN" \
+  --dir /tmp \
+  --clobber || { echo "ERROR: Failed to download plugin release"; exit 1; }
+
+tar xzf "/tmp/$ASSET_PATTERN" -C "$PLUGIN_DIR" || { echo "ERROR: Failed to extract plugin"; exit 1; }
+
+# Generate config for testing against the privateer repo
+cat > "$CONFIG_FILE" <<EOF
+loglevel: trace
+write-directory: evaluation_results
+write: true
+output: yaml
+services:
+  privateer:
+    plugin: pvtr-github-repo
+    policy:
+      catalogs:
+        - osps-baseline
+      applicability:
+        - Maturity Level 1
+    vars:
+      owner: privateerproj
+      repo: privateer
+      token: ${GITHUB_TOKEN}
+EOF
+
+# Run privateer with the plugin
+./privateer run -b "$PLUGIN_DIR" -c "$CONFIG_FILE" || STATUS=1
+
+exit $STATUS


### PR DESCRIPTION
## What

Add an integration test that downloads the latest pvtr-github-repo plugin
release and runs it against the privateer repository using the OSPS
baseline catalog at Maturity Level 1.

## Why

Validates that privateer can discover, load, and execute a real plugin
end-to-end in CI, catching integration issues that unit and acceptance
tests cannot. Creates more trust.

## Notes

- We are using octo-sts for temporary tokens
- The script detects OS/architecture to download the correct release
  asset, so it works both locally and in CI
  - tested locally and it works
- The verification step greps for the summary line pattern rather than
  asserting specific pass/fail counts, so it won't break as the plugin
  or repo evolves