### PR TITLE
ci: add security insights validation and bump osps-baseline-action to v1.2.0

### DIFF
--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -29,7 +29,7 @@ jobs:
           identity: privateer
 
       - name: Open Source Project Security Baseline Scanner
-        uses: revanite-io/osps-baseline-action@v1.0.0
+        uses: revanite-io/osps-baseline-action@6d2d044b2ec5299d4d8b82da3027c7f5ddadda6e
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}

--- a/.github/workflows/security-insights.yml
+++ b/.github/workflows/security-insights.yml
@@ -1,0 +1,30 @@
+---
+name: Validate Security Insights
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/security-insights.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/security-insights.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate Security Insights
+        uses: revanite-io/security-insights-action@85c35a5b75f2772e0462323d7b4fcbab5fc1aff2
+        with:
+          file: .github/security-insights.yml


### PR DESCRIPTION
## What

Added a new workflow to validate the security-insights.yml file on pushes and PRs to main, and bumped the osps-baseline-action from v1.0.0 to v1.2.0.

## Why

The security insights validation ensures the security-insights.yml file stays well-formed as it's updated. The action bump picks up improvements in the baseline scanner.

## Notes

The security-insights-action is pinned to a full commit SHA rather than a semver tag — this is intentional for supply chain safety but means future updates require manually updating the hash.