### PR TITLE
fix: set universal_binaries name_template to match build binary name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,3 +69,6 @@ release:
 
 universal_binaries:
   - replace: true
+    # name_template defaults to {{ .ProjectName }} (repo name: "privateer"),
+    # which overrides the build binary name when replace: true
+    name_template: pvtr


### PR DESCRIPTION
## What

Set the name_template field on universal_binaries in .goreleaser.yaml to "pvtr" so the macOS universal binary matches the configured build binary name.

## Why

The universal_binaries name_template defaults to {{ .ProjectName }}, which resolves to the repo name "privateer". With replace: true, this overwrites the correctly named "pvtr" binary with one named "privateer", causing `brew install privateerproj/tap/pvtr` to fail with `ENOENT: No such file or directory - pvtr` since the formula expects a binary named "pvtr".

## Notes

- A new release must be cut after this merges for the homebrew formula to work
- The archive filenames will still use "privateer" (e.g., privateer_Darwin_all.tar.gz) since ProjectName is unchanged — only the binary inside is affected