### PR TITLE
feat: add --organization flag and adapt to SDK PluginConfig

### DIFF
--- a/cmd/generate-plugin.go
+++ b/cmd/generate-plugin.go
@@ -36,9 +36,8 @@ func init() {
 	rootCmd.AddCommand(genPluginCmd)
 }
 
-// generatePlugin sets up the templating environment and generates a new plugin
-// based on the provided source file, service name, and output directory.
-// It returns any errors encountered to the caller (e.g. the cobra command handler).
+// generatePlugin validates the plugin configuration and generates a new plugin
+// from templates. It returns any errors encountered to the caller.
 func generatePlugin() error {
 	cfg, err := command.SetupTemplatingEnvironment(logger)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
-	github.com/privateerproj/privateer-sdk v1.20.0
+	github.com/privateerproj/privateer-sdk v1.21.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/privateerproj/privateer-sdk v1.20.0 h1:QdXhUJIG9XCfcD+ar9PFMv5Gjf8gzETzKYgnJ7tLBTA=
-github.com/privateerproj/privateer-sdk v1.20.0/go.mod h1:kU4oaUY9CyqjxDkxs/TEjKvnkSt5MvDtqIhn0ZvgG8U=
+github.com/privateerproj/privateer-sdk v1.21.0 h1:FhUAnOn1cbnGZx52WjINhpmSdoTCZYKGC2j98A3wbpk=
+github.com/privateerproj/privateer-sdk v1.21.0/go.mod h1:kU4oaUY9CyqjxDkxs/TEjKvnkSt5MvDtqIhn0ZvgG8U=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Depends on https://github.com/privateerproj/privateer-sdk/pull/176 (need to update go.mod privateer-sdk version here in go.mod once merged)

## What

Added the --organization / -g flag to the generate-plugin command and updated the generatePlugin function to use the SDK's new PluginConfig struct return from SetupTemplatingEnvironment.

## Why

The SDK now returns a PluginConfig struct instead of individual string values and requires an organization parameter for template rendering (privateerproj/privateer-sdk#176).

## Notes

- This depends on the SDK PR privateerproj/privateer-sdk#176 being merged and released before this can land
- The -g shorthand was chosen to avoid conflict with existing -n (service-name), -p (source-path), and -o (output-dir) flags