### PR TITLE
fix(ci): add fetch-depth 0 to integration test checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## What

Add `fetch-depth: 0` to the integration test job's checkout step so
that git tags are available during the build.

## Why

The Makefile uses `git describe --tags` to inject the version at build
time via ldflags. Without full git history in a shallow clone, this
fails with:

```
fatal: No names found, cannot describe anything.
```

The binary still works because main.go falls back to "edge", but the
error is noisy and the version string is less informative than it
should be.

## Notes

- Only the integration job is changed — the CI job doesn't need tags since it doesn't build the binary via ldflags
- The "Detect Changes" job already uses `fetch-depth: 0` for its diff logic

## Testing

- The fix is a CI-only change — verification will come from the integration test job in this PR's own CI run, where `git describe --tags` should succeed without the `fatal` error