### PR TITLE
chore: upgrade go to 1.26.2

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      dependency-graph: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      dependency-graph: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.22@sha256:07e91d24f6330432729082bb580983181809e0a48f0f38ecde26868d4568c6ac AS build
+FROM golang:1.26.2-alpine3.22@sha256:c259ff7ffa06f1fd161a6abfa026573cf00f64cfd959c6d2a9d43e3ff63e8729 AS build
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/privateerproj/privateer
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3


### PR DESCRIPTION
## What

Upgrade Go from 1.26.1 to 1.26.2 in go.mod and the Dockerfile base image.

## Why

go1.26.2 fixes 4 vulnerabilities in the standard library:

- GO-2026-4947: unexpected work during chain building (crypto/x509)
- GO-2026-4946: inefficient policy validation (crypto/x509)
- GO-2026-4870: unauthenticated TLS 1.3 KeyUpdate DoS (crypto/tls)
- GO-2026-4866: case-sensitive excludedSubtrees auth bypass (crypto/x509)

## Notes

- Dockerfile digest updated to match the new golang:1.26.2-alpine3.22 image