### PR TITLE
ci: add explicit permissions to post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   first_test_job:
     name: Find extra commits


### PR DESCRIPTION
## Summary

Add a top-level `permissions` block to the `post-merge.yml` workflow, restricting the `GITHUB_TOKEN` to `contents: write` — the minimum scope needed for the `RubbaBoy/BYOB` action to push badge data to the `shields` branch.

Without an explicit `permissions` block, the workflow inherits the repository's default token permissions, which may be broader than necessary. This follows the principle of least privilege and limits the blast radius if a third-party action is compromised.

## Limitations

- The `RubbaBoy/BYOB` action could not be fully end-to-end tested on a fork