### PR TITLE
ci: adopt consolidated ospo-reusable-workflows release.yaml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,44 +8,30 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate artifact attestations
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
+      goreleaser-config-path: .goreleaser.yaml
+      go-version-file: go.mod
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
+  update-homebrew:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read     # Required by harden-runner
+      id-token: write    # Federate via octo-sts for cross-repo push
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  update-homebrew:
-    needs: [release, goreleaser]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
+          egress-policy: audit
       - name: Download archives and compute checksums
         id: checksums
         env:
@@ -68,6 +54,7 @@ jobs:
         with:
           repository: privateerproj/homebrew-tap
           token: ${{ steps.octo-sts.outputs.token }}
+          persist-credentials: true # Required for git push of the formula update
       - name: Update homebrew formula
         env:
           TAG: ${{ needs.release.outputs.full-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,6 @@ on:
 jobs:
   release:
     permissions:
-      # Union of all permissions declared by jobs in the called workflow.
-      # GitHub validates each nested job's `permissions:` at startup before
-      # evaluating its `if:`, except when the gate folds statically to false.
-      # `release_image` (`inputs.image-name != ''`) and `release_goreleaser`
-      # (`inputs.goreleaser-config-path != ''`) are string comparisons that
-      # the validator can't fold, so their perms must be granted even when
-      # those jobs end up skipped at runtime.
       contents: write       # create_release, publish_release: tag + release
       pull-requests: read   # create_release: read PR labels for release-drafter
       id-token: write       # release_goreleaser, release_image: attestation OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read   # Read PR labels for release-drafter
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate artifact attestations
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,19 @@ on:
 jobs:
   release:
     permissions:
-      contents: write       # Create release and push tags
-      pull-requests: read   # Read PR labels for release-drafter
-      id-token: write       # Federate for artifact attestation
-      attestations: write   # Generate artifact attestations
+      # Union of all permissions declared by jobs in the called workflow.
+      # GitHub validates each nested job's `permissions:` at startup before
+      # evaluating its `if:`, except when the gate folds statically to false.
+      # `release_image` (`inputs.image-name != ''`) and `release_goreleaser`
+      # (`inputs.goreleaser-config-path != ''`) are string comparisons that
+      # the validator can't fold, so their perms must be granted even when
+      # those jobs end up skipped at runtime.
+      contents: write       # create_release, publish_release: tag + release
+      pull-requests: read   # create_release: read PR labels for release-drafter
+      id-token: write       # release_goreleaser, release_image: attestation OIDC
+      attestations: write   # release_goreleaser, release_image: build provenance
+      packages: write       # release_image: push container image (gated, but validated)
+      discussions: write    # release_discussion: announcement (gated, defensive)
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,15 +42,16 @@ archives:
       - goos: windows
         formats: ["zip"]
 
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+checksum:
+  name_template: "checksums.txt"
 
+# release-drafter (via the ospo-reusable-workflows release.yaml) owns the
+# GitHub release and changelog. GoReleaser only builds and uploads artifacts.
 release:
-  prerelease: auto
+  disable: true
+
+changelog:
+  disable: true
 
 universal_binaries:
   - replace: true


### PR DESCRIPTION
## What

Switch the release workflow to the consolidated `release.yaml` reusable workflow at v1.0.0 (`592067a6...`), remove the separate `goreleaser` job now that the reusable workflow runs GoReleaser internally, update the GoReleaser config to disable its release/changelog (release-drafter owns those) and pin `checksums.txt`, and add a "Breaking Changes" changelog category to release-drafter.

## Why

The reusable workflow used to be three chained workflows (release, release-image, release-discussion) that each caller had to wire up. v1.0.0 collapses them into a single draft-first pipeline that also takes ownership of running GoReleaser and uploading artifacts to the draft release before publish. Letting the reusable workflow drive GoReleaser means one source of truth for tags, attestation, and artifact upload, and removes ~25 lines of bespoke job from this repo. The "Breaking Changes" category matches the upstream release-drafter template (github-community-projects/ospo-reusable-workflows#134) so the `breaking` label, which already triggers a major version bump, also surfaces in its own changelog section.

## Notes

- The reusable workflow validates `.goreleaser.yaml` has `release.disable: true` via `yq` and hard-fails if missing — keep that line.
- `release` job now requests `id-token: write` and `attestations: write`; the called workflow can only request a subset of what the caller grants, so dropping these silently disables build provenance instead of erroring.
- `update-homebrew` now `needs: release` only. Because the reusable workflow's internal `publish_release` is the last step, the homebrew job correctly waits for the release to be published before downloading archives.
- Added `harden-runner` as the first step of `update-homebrew` and made `persist-credentials: true` on the `homebrew-tap` checkout explicit (the octo-sts token is required for the subsequent `git push`).
- `create-discussion` is intentionally not enabled; flip on later with the input plus `discussion-repository-id` / `discussion-category-id` secrets if we want auto-announcements.

## Testing

- `make test` — passes (`cmd` package tests green).
- `goreleaser check --config .goreleaser.yaml` — config validated; "release is disabled" pipe-skip notice as expected.
- End-to-end release flow is not exercised locally; first real validation will be the next merged PR carrying a `feature`/`fix`/`breaking`/`vuln`/`release` label that fires `pull_request_target: closed`. Watch for: draft release created by release-drafter, `release_goreleaser` job uploading `pvtr_Darwin_all.tar.gz`, `pvtr_Linux_x86_64.tar.gz`, `pvtr_Linux_arm64.tar.gz`, plus `checksums.txt`; artifact attestation succeeding (public repo); `publish_release` flipping the draft to published; `update-homebrew` then downloading the archives and pushing the formula bump to `privateerproj/homebrew-tap`.