### PR TITLE
chore: name release archives pvtr_* instead of privateer_*

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,9 +47,9 @@ jobs:
           TAG: ${{ needs.release.outputs.full-tag }}
         run: |
           BASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/download/${TAG}"
-          curl -fSL "$BASE_URL/privateer_Darwin_all.tar.gz" -o darwin.tar.gz
-          curl -fSL "$BASE_URL/privateer_Linux_x86_64.tar.gz" -o linux_amd64.tar.gz
-          curl -fSL "$BASE_URL/privateer_Linux_arm64.tar.gz" -o linux_arm64.tar.gz
+          curl -fSL "$BASE_URL/pvtr_Darwin_all.tar.gz" -o darwin.tar.gz
+          curl -fSL "$BASE_URL/pvtr_Linux_x86_64.tar.gz" -o linux_amd64.tar.gz
+          curl -fSL "$BASE_URL/pvtr_Linux_arm64.tar.gz" -o linux_arm64.tar.gz
           {
             echo "darwin_sha256=$(sha256sum darwin.tar.gz | awk '{print $1}')"
             echo "linux_amd64_sha256=$(sha256sum linux_amd64.tar.gz | awk '{print $1}')"
@@ -73,8 +73,11 @@ jobs:
           LINUX_AMD64_SHA: ${{ steps.checksums.outputs.linux_amd64_sha256 }}
           LINUX_ARM64_SHA: ${{ steps.checksums.outputs.linux_arm64_sha256 }}
         run: |
-          # Update download URLs to new tag
+          # Point the formula at this tag's assets. The archive prefix is rewritten
+          # alongside the tag so the formula tracks GoReleaser's project_name; both
+          # substitutions are idempotent once the formula is already current.
           sed -i "s|releases/download/v[^/]*/|releases/download/${TAG}/|g" pvtr.rb
+          sed -i "s|/privateer_|/pvtr_|g" pvtr.rb
 
           # Update SHA256 checksums in order: Darwin, Linux x86_64, Linux arm64
           awk -v d="$DARWIN_SHA" -v x="$LINUX_AMD64_SHA" -v a="$LINUX_ARM64_SHA" '

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,11 @@
 
 version: 2
 
+# Without this, ProjectName falls back to the repo/module name ("privateer"),
+# which names every release archive privateer_* and forces the universal binary
+# to be renamed back to pvtr below.
+project_name: pvtr
+
 before:
   hooks:
     - go mod tidy
@@ -55,6 +60,7 @@ changelog:
 
 universal_binaries:
   - replace: true
-    # name_template defaults to {{ .ProjectName }} (repo name: "privateer"),
-    # which overrides the build binary name when replace: true
+    # name_template defaults to {{ .ProjectName }}, which overrides the build
+    # binary name when replace: true. Stated explicitly so the binary stays
+    # pvtr even if ProjectName changes.
     name_template: pvtr


### PR DESCRIPTION
GoReleaser derives `ProjectName` from the repo/module name when unset, so archives shipped as `privateer_*` even though the binary, CLI, and formula are all `pvtr`. Sets `project_name: pvtr`.

The homebrew job is updated in the same commit so there is no broken window: it fetches the renamed archives, and the formula rewrite now normalizes the archive prefix alongside the tag, so the tap flips atomically on the next release instead of pointing at URLs that no longer resolve.

Verified with `goreleaser release --snapshot`: `pvtr_Darwin_all.tar.gz`, `pvtr_Linux_{x86_64,arm64,i386}.tar.gz`, `pvtr_Windows_*.zip`, each still containing a binary named `pvtr`.