### PR TITLE
fix: improve cross-platform installation resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,32 @@ brew install privateerproj/tap/pvtr
 /bin/bash -c "$(curl -sSL https://raw.githubusercontent.com/privateerproj/privateer/main/install.sh)"
 ```
 
+Installs the latest release to `~/.privateer/bin`, verifying its checksum before
+installing. Pass flags after `--`:
+
+```bash
+/bin/bash -c "$(curl -sSL https://raw.githubusercontent.com/privateerproj/privateer/main/install.sh)" -- -p /usr/local/bin -y
+```
+
+| Flag | Effect |
+| --- | --- |
+| `-p <dir>` | Install to `<dir>` instead of `~/.privateer/bin` |
+| `-v <version>` | Install a specific release, e.g. `v0.22.0`, instead of the latest |
+| `-y` | Add the install directory to `PATH` without prompting |
+| `-h` | Print usage and exit |
+
+`PVTR_VERSION` is equivalent to `-v`; the flag wins if both are set. Pin a
+version to keep CI reproducible:
+
+```bash
+PVTR_VERSION=v0.22.0 /bin/bash -c "$(curl -sSL https://raw.githubusercontent.com/privateerproj/privateer/main/install.sh)" -- -p /usr/local/bin -y
+```
+
+Without `-y` the script asks before editing your shell config, and prints the
+`PATH` line for you to add yourself if you decline or it is run unattended.
+Installing to a directory you do not own (such as `/usr/local/bin`) requires
+`sudo`.
+
 #### Option 3: Download from Releases
 
 Download the latest release from [GitHub Releases](https://github.com/privateerproj/privateer/releases).

--- a/install.sh
+++ b/install.sh
@@ -1,229 +1,316 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# Constants
+REPO="privateerproj/privateer"
 DEFAULT_INSTALL_DIR="$HOME/.privateer/bin"
-PVTR_REPO="privateerproj/privateer"
-LATEST_RELEASE_URL="https://api.github.com/repos/${PVTR_REPO}/releases/latest"
+DEFAULT_VERSION="latest"
 
-# Detect OS (darwin = macOS, linux = Linux, msys or cygwin = Windows)
-OS=""
-case "$(uname -s)" in
-    Darwin)
-        OS="darwin"
-        ;;
-    Linux)
-        OS="linux"
-        ;;
-    CYGWIN*|MSYS*|MINGW*)
-        OS="windows"
-        ;;
-    *)
-        echo "Unsupported Environment: $(uname -s)"
-        exit 1
-        ;;
-esac
+# Set by detect_platform. A global rather than a stdout value because `fail`
+# calls `exit`, which only unwinds the subshell inside a `$(...)` and would
+# leave the caller running with an empty platform.
+PLATFORM=""
 
-# Detect Architecture (x86_64 = amd64, arm64 = arm64, i386/i686 = 386)
-ARCH=""
-case "$(uname -m)" in
-    x86_64)
-        ARCH="x86_64"
-        ;;
-    i386)
-        ARCH="i386"
-        ;;
-    arm64)
-        ARCH="arm64"
-        ;;
-    *)
-        echo "Unsupported Architecture: $(uname -m)"
-        exit 1
-        ;;
-esac
+usage() {
+    cat <<EOF
+Usage: install.sh [-p install_dir] [-v version] [-y] [-h]
 
-extract_download_urls() {
-    local release_json="$1"
+  -p  Install directory (default: $DEFAULT_INSTALL_DIR)
+  -v  Release to install, e.g. v0.22.0 (default: $DEFAULT_VERSION)
+  -y  Add the install directory to PATH in your shell config without prompting
+  -h  Show this help
 
-    printf '%s' "$release_json" \
-        | tr '\n' ' ' \
-        | grep -Eo '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' \
-        | sed -E 's/^"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]+)"$/\1/'
+Environment:
+  PVTR_VERSION  Same as -v. The flag wins if both are set.
+EOF
 }
 
-find_release_asset_url() {
-    local release_json="$1"
-    local asset_pattern="$2"
-
-    extract_download_urls "$release_json" | grep -Ei "$asset_pattern" | head -n 1
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
 }
 
-download_latest_release() {
-    local install_dir="$1"
-    local install_file="$install_dir/pvtr"
+# Overridden by the test suite to exercise the prompt without a pty.
+is_interactive() {
+    [[ -t 0 && -t 1 ]]
+}
 
-    # Ensure the directory exists
-    mkdir -p "$install_dir"
+# Absolute path with redundant '.' and '/' segments collapsed, so the PATH line
+# printed to the user is clean. `realpath` is absent from a stock macOS, so this
+# stays in shell. '..' is deliberately left in place: resolving it lexically
+# would give the wrong answer under a symlinked parent, and a PATH entry
+# containing '..' still works.
+abspath() {
+    local path="$1" part result=""
+    local -a parts=()
 
-    # Fetch release metadata once
-    local release_json
-    release_json=$(curl -s "${LATEST_RELEASE_URL}")
+    [[ "$path" == /* ]] || path="$PWD/$path"
 
-    # Build the grep pattern based on OS
-    local pattern
-    if [[ "$OS" == "darwin" ]]; then
-        pattern="${OS}"
+    local IFS='/'
+    read -r -a parts <<< "$path"
+    for part in "${parts[@]}"; do
+        [[ -z "$part" || "$part" == "." ]] && continue
+        result="$result/$part"
+    done
+
+    printf '%s\n' "${result:-/}"
+}
+
+detect_platform() {
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin)
+            # Darwin archives are universal binaries, so the arch is irrelevant.
+            PLATFORM="Darwin_all"
+            return
+            ;;
+        Linux) ;;
+        *)
+            fail "Unsupported OS: $os. Download a release directly from https://github.com/${REPO}/releases"
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64 | amd64) arch="x86_64" ;;
+        aarch64 | arm64) arch="arm64" ;;
+        i386 | i686) arch="i386" ;;
+        *)
+            fail "Unsupported architecture: $arch. Download a release directly from https://github.com/${REPO}/releases"
+            ;;
+    esac
+
+    PLATFORM="Linux_${arch}"
+}
+
+release_base_url() {
+    local version="$1"
+
+    if [[ "$version" == "latest" ]]; then
+        printf '%s\n' "https://github.com/${REPO}/releases/latest/download"
+        return
+    fi
+
+    [[ "$version" == v* ]] || version="v$version"
+    printf '%s\n' "https://github.com/${REPO}/releases/download/${version}"
+}
+
+# Checked by ensure_prerequisites, so this never has to report a missing tool.
+# Reporting one here would be swallowed anyway: the caller runs it in a command
+# substitution, where `fail` would exit only the subshell and leave an empty
+# digest that reads as a checksum mismatch.
+sha256() {
+    if command -v sha256sum > /dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
     else
-        pattern="${OS}.*${ARCH}"
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# Fail before downloading rather than part-way through.
+ensure_prerequisites() {
+    local tool
+    for tool in curl tar awk; do
+        command -v "$tool" > /dev/null 2>&1 || fail "$tool is required but was not found."
+    done
+
+    command -v sha256sum > /dev/null 2>&1 || command -v shasum > /dev/null 2>&1 \
+        || fail "Neither sha256sum nor shasum is available; cannot verify the download."
+}
+
+# Fail before downloading rather than after, so `-p /usr/local/bin` (which needs
+# root on most systems) reports something actionable.
+ensure_writable_dir() {
+    local dir="$1" ancestor="$1"
+
+    if [[ -d "$dir" ]]; then
+        [[ -w "$dir" ]] || fail "$dir is not writable. Re-run with sudo, or choose another directory with -p."
+        return
     fi
 
-    # Fetch the download URL for the latest release binary
-    local url
-    url=$(find_release_asset_url "$release_json" "$pattern")
+    while [[ ! -d "$ancestor" ]]; do
+        ancestor="$(dirname "$ancestor")"
+    done
 
-    if [[ -z "$url" ]]; then
-        echo "Failed to fetch the download URL for the latest release."
-        exit 1
+    [[ -w "$ancestor" ]] || fail "Cannot create $dir: $ancestor is not writable. Re-run with sudo, or choose another directory with -p."
+}
+
+cleanup() {
+    [[ -n "${tmp_dir:-}" ]] && rm -rf "$tmp_dir"
+    [[ -n "${staged_binary:-}" ]] && rm -f "$staged_binary"
+    return 0
+}
+
+# Downloads the first candidate asset name that exists and echoes that name.
+# Asset names have changed across releases, so a pinned older version needs the
+# name that release actually used. The probe is deliberately quiet (-s, no -S):
+# a miss is expected and the caller reports the aggregate failure.
+fetch_first_asset() {
+    local base_url="$1" dest="$2"
+    shift 2
+
+    local name
+    for name in "$@"; do
+        if curl -fsL --retry 3 --retry-delay 1 -o "$dest" "$base_url/$name"; then
+            printf '%s\n' "$name"
+            return 0
+        fi
+    done
+    return 1
+}
+
+download_release() {
+    local install_dir="$1" platform="$2" base_url="$3" version="$4"
+    local archive checksums expected actual
+    local -a checksum_names=("checksums.txt")
+
+    # Not local: the EXIT trap runs after this function returns.
+    tmp_dir="$(mktemp -d)"
+    staged_binary=""
+    trap cleanup EXIT
+
+    # v0.22.0 and earlier published archives as privateer_* rather than pvtr_*.
+    archive="$(fetch_first_asset "$base_url" "$tmp_dir/archive.tar.gz" \
+        "pvtr_${platform}.tar.gz" "privateer_${platform}.tar.gz")" \
+        || fail "Failed to download a release archive for ${platform} from $base_url"
+    echo "Downloaded $archive"
+
+    # v0.21.0 and earlier named the checksums file privateer_<version>_checksums.txt.
+    # Only worth probing for a pinned version; "latest" is always v0.22.0 or newer.
+    if [[ "$version" != "latest" ]]; then
+        checksum_names+=("privateer_${version#v}_checksums.txt")
     fi
 
-    # Fetch the checksums file URL
-    local checksums_url
-    checksums_url=$(find_release_asset_url "$release_json" 'checksums\.txt$')
+    checksums="$(fetch_first_asset "$base_url" "$tmp_dir/checksums.txt" "${checksum_names[@]}")" \
+        || fail "Failed to download a checksums file from $base_url; refusing to install an unverified binary."
+    echo "Verifying against $checksums"
 
-    if [[ -z "$checksums_url" ]]; then
-        echo "ERROR: No checksums file found in release assets. Refusing to install an unverified binary."
-        exit 1
-    fi
+    expected="$(awk -v name="$archive" '$2 == name { print $1 }' "$tmp_dir/checksums.txt")"
+    [[ -n "$expected" ]] || fail "No entry for $archive in $checksums; refusing to install an unverified binary."
 
-    # Create a temporary directory for download and verification
-    local tmp_dir
-    tmp_dir=$(mktemp -d)
-    trap 'rm -rf "$tmp_dir"' RETURN
+    actual="$(sha256 "$tmp_dir/archive.tar.gz")"
+    [[ "$actual" == "$expected" ]] || fail "Checksum mismatch for $archive.
+  Expected: $expected
+  Actual:   $actual
+The download is corrupt or has been altered in transit."
+    echo "Checksum verified."
 
-    local archive_name
-    archive_name=$(basename "$url")
-    local tmp_archive="$tmp_dir/$archive_name"
+    tar -xzf "$tmp_dir/archive.tar.gz" -C "$tmp_dir" pvtr \
+        || fail "Archive $archive does not contain a pvtr binary."
 
-    echo "Downloading from: $url"
+    # Stage inside the install dir, then rename. A rename within one filesystem
+    # is atomic, so an interrupted install cannot leave a truncated pvtr behind,
+    # and an in-use or code-signed binary is replaced rather than overwritten.
+    mkdir -p "$install_dir" || fail "Failed to create $install_dir"
+    staged_binary="$install_dir/.pvtr.download.$$"
+    cp "$tmp_dir/pvtr" "$staged_binary"
+    chmod 755 "$staged_binary"
+    mv -f "$staged_binary" "$install_dir/pvtr"
+    staged_binary=""
 
-    # Download the archive to a temporary file
-    curl -fSL -o "$tmp_archive" "$url"
-
-    echo "Verifying checksum..."
-    local tmp_checksums="$tmp_dir/checksums.txt"
-    if ! curl -fSL -o "$tmp_checksums" "$checksums_url"; then
-        echo "ERROR: Failed to download checksums file. Refusing to install an unverified binary."
-        exit 1
-    fi
-
-    # Extract the expected checksum for our archive (exact filename match, not regex)
-    local expected_checksum
-    expected_checksum=$(awk -v name="$archive_name" '$2 == name { print $1 }' "$tmp_checksums")
-
-    if [[ -z "$expected_checksum" ]]; then
-        echo "ERROR: Could not find checksum for ${archive_name} in checksums file."
-        echo "Aborting installation for security. To skip verification, download manually."
-        exit 1
-    fi
-
-    # Compute actual checksum
-    local actual_checksum
-    if command -v sha256sum &>/dev/null; then
-        actual_checksum=$(sha256sum "$tmp_archive" | awk '{print $1}')
-    elif command -v shasum &>/dev/null; then
-        actual_checksum=$(shasum -a 256 "$tmp_archive" | awk '{print $1}')
-    else
-        echo "ERROR: No sha256sum or shasum found. Cannot verify checksum."
-        exit 1
-    fi
-
-    if [[ "$actual_checksum" != "$expected_checksum" ]]; then
-        echo "CHECKSUM MISMATCH!"
-        echo "  Expected: $expected_checksum"
-        echo "  Actual:   $actual_checksum"
-        echo "The downloaded file may have been tampered with. Aborting."
-        exit 1
-    fi
-
-    echo "Checksum verified OK."
-
-    # Extract the verified archive
-    tar xf "$tmp_archive" -C "$install_dir"
-
-    # Ensure the binary is executable
-    chmod +x "$install_file"
-
-    echo "Downloaded binary to $install_file"
+    echo "Installed $install_dir/pvtr"
 }
 
 update_path() {
-    local install_dir="$1"
+    local install_dir="$1" assume_yes="$2"
+    local config_file path_line consent reply
 
-    # Check if the install directory is already in PATH
-    if [[ ":$PATH:" != *":$install_dir:"* ]]; then
-        echo "$install_dir is not in the PATH."
+    case ":$PATH:" in
+        *":$install_dir:"*) return ;;
+    esac
 
-        # Detect current shell
-        current_shell=$(basename "$SHELL")
-
-        case "$current_shell" in
-            bash)
+    case "$(basename "${SHELL:-}")" in
+        bash)
+            # macOS terminals start login shells, which read .bash_profile and
+            # never source .bashrc.
+            if [[ "$(uname -s)" == "Darwin" ]]; then
                 config_file="$HOME/.bash_profile"
-                ;;
-            zsh)
-                config_file="$HOME/.zshrc"
-                ;;
-            fish)
-                config_file="$HOME/.config/fish/config.fish"
-                ;;
-            *)
-                echo "Unsupported shell: $current_shell. You may need to manually add $install_dir to your PATH."
-                return
-                ;;
-        esac
+            else
+                config_file="$HOME/.bashrc"
+            fi
+            path_line="export PATH=\"$install_dir:\$PATH\""
+            ;;
+        zsh)
+            config_file="$HOME/.zshrc"
+            path_line="export PATH=\"$install_dir:\$PATH\""
+            ;;
+        fish)
+            config_file="$HOME/.config/fish/config.fish"
+            path_line="fish_add_path \"$install_dir\""
+            ;;
+        *)
+            echo "To use pvtr, add $install_dir to your PATH."
+            return
+            ;;
+    esac
 
-        # Check if the path is already added to the config file
-        if ! grep -q "$install_dir" "$config_file"; then
-            echo "export PATH=\"$install_dir:\$PATH\"" >> "$config_file"
-            echo "$install_dir added to $config_file"
-            source $config_file
-        else
-            echo "$install_dir is already in $config_file."
+    # Ignore commented-out lines so a leftover comment does not read as configured.
+    if grep -vE '^[[:space:]]*#' "$config_file" 2> /dev/null | grep -qF -- "$install_dir"; then
+        echo "$config_file already references $install_dir. Restart your shell to use pvtr."
+        return
+    fi
+
+    consent="$assume_yes"
+    if [[ "$consent" != true ]] && is_interactive; then
+        reply=""
+        # `read` returns non-zero at EOF (Ctrl-D). Treat that as declining rather
+        # than letting `set -e` abort an otherwise complete install.
+        read -r -p "Add $install_dir to PATH in $config_file? [y/N] " reply || reply=""
+        if [[ "$reply" == [yY]* ]]; then
+            consent=true
         fi
+    fi
+
+    if [[ "$consent" == true ]]; then
+        mkdir -p "$(dirname "$config_file")"
+        printf '\n%s\n' "$path_line" >> "$config_file"
+        echo "Added $install_dir to PATH in $config_file. Restart your shell to use pvtr."
     else
-        echo "$install_dir is already in the PATH."
+        echo "To use pvtr, add $install_dir to your PATH:"
+        echo "  $path_line"
     fi
 }
 
-# Main logic
 main() {
-    local install_dir="$DEFAULT_INSTALL_DIR"
+    local install_dir="$DEFAULT_INSTALL_DIR" assume_yes=false
+    local version="${PVTR_VERSION:-$DEFAULT_VERSION}"
 
-    # Handle CLI arguments for installation path override
-    while getopts "p:" opt; do
-        case $opt in
-            p)
-                install_dir="$OPTARG"
+    while getopts "p:v:yh" opt; do
+        case "$opt" in
+            p) install_dir="$OPTARG" ;;
+            v) version="$OPTARG" ;;
+            y) assume_yes=true ;;
+            h)
+                usage
+                exit 0
                 ;;
             *)
-                echo "Usage: $0 [-p install_path]"
+                usage >&2
                 exit 1
                 ;;
         esac
     done
+    shift $((OPTIND - 1))
 
-    mkdir -p "$install_dir"
+    if [[ $# -gt 0 ]]; then
+        echo "ERROR: unexpected argument: $1" >&2
+        usage >&2
+        exit 1
+    fi
 
-    # Download the latest release
-    download_latest_release "$install_dir"
-
-    # Ensure the binary is accessible via PATH
-    update_path "$install_dir"
-
-    echo "pvtr installation complete!"
+    install_dir="$(abspath "$install_dir")"
+    ensure_prerequisites
+    detect_platform
+    ensure_writable_dir "$install_dir"
+    download_release "$install_dir" "$PLATFORM" "$(release_base_url "$version")" "$version"
+    update_path "$install_dir" "$assume_yes"
+    echo "pvtr installation complete."
 }
 
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# BASH_SOURCE is unset under `curl | bash` and `bash -c`, where $0 is the
+# fallback; when sourced (see test/install_test.sh) the two differ.
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
     main "$@"
 fi

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ The download is corrupt or has been altered in transit."
     # is atomic, so an interrupted install cannot leave a truncated pvtr behind,
     # and an in-use or code-signed binary is replaced rather than overwritten.
     mkdir -p "$install_dir" || fail "Failed to create $install_dir"
-    staged_binary="$install_dir/.pvtr.download.$$"
+    staged_binary="$(mktemp "$install_dir/.pvtr.download.XXXXXX")"
     cp "$tmp_dir/pvtr" "$staged_binary"
     chmod 755 "$staged_binary"
     mv -f "$staged_binary" "$install_dir/pvtr"

--- a/test/install_test.sh
+++ b/test/install_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -6,129 +6,64 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INSTALL_SCRIPT="$REPO_ROOT/install.sh"
 
-release_json_with_checksums() {
-        cat <<'EOF'
-{
-    "assets": [
-        {
-            "browser_download_url": "https://example.test/pvtr_Linux_x86_64.tar.gz"
-        },
-        {
-            "browser_download_url": "https://example.test/checksums.txt"
-        }
-    ]
-}
-EOF
-}
-
-release_json_without_checksums() {
-        cat <<'EOF'
-{
-    "assets": [
-        {
-            "browser_download_url": "https://example.test/pvtr_Linux_x86_64.tar.gz"
-        }
-    ]
-}
-EOF
-}
-
-release_json_with_checksums_compact() {
-    printf '%s' '{"assets":[{"browser_download_url":"https://example.test/pvtr_Linux_x86_64.tar.gz"},{"browser_download_url":"https://example.test/checksums.txt"}]}'
-}
-
 make_mock_commands() {
     local mock_bin="$1"
 
     cat <<'EOF' > "$mock_bin/uname"
 #!/bin/bash
 case "$1" in
-    -s)
-        printf '%s\n' "${MOCK_UNAME_S:-Linux}"
-        ;;
-    -m)
-        printf '%s\n' "${MOCK_UNAME_M:-x86_64}"
-        ;;
-    *)
-        /usr/bin/uname "$@"
-        ;;
+    -s) printf '%s\n' "${MOCK_UNAME_S:-Linux}" ;;
+    -m) printf '%s\n' "${MOCK_UNAME_M:-x86_64}" ;;
+    *) /usr/bin/uname "$@" ;;
 esac
 EOF
 
+    # Serves the release archive only under MOCK_ARCHIVE_NAME, so a request for
+    # any other name 404s the way GitHub would. Every requested URL is appended
+    # to MOCK_URL_LOG so tests can assert which release was fetched.
     cat <<'EOF' > "$mock_bin/curl"
 #!/bin/bash
 set -euo pipefail
 
 output_file=""
 url=""
-
 while (($#)); do
     case "$1" in
-        -o)
-            output_file="$2"
-            shift 2
-            ;;
-        -f|-S|-s|-L|-SL|-fSL)
-            shift
-            ;;
-        -*)
-            shift
-            ;;
-        *)
-            url="$1"
-            shift
-            ;;
+        -o) output_file="$2"; shift 2 ;;
+        --retry | --retry-delay) shift 2 ;;
+        -*) shift ;;
+        *) url="$1"; shift ;;
     esac
 done
 
-if [[ -z "$url" ]]; then
-    exit 1
-fi
-
-if [[ "$url" == *"/releases/latest" ]]; then
-    if [[ -n "$output_file" ]]; then
-        printf '%s' "$MOCK_RELEASE_JSON" > "$output_file"
-    else
-        printf '%s' "$MOCK_RELEASE_JSON"
-    fi
-    exit 0
-fi
+[[ -n "$url" ]] || exit 1
+printf '%s\n' "$url" >> "${MOCK_URL_LOG:-/dev/null}"
 
 if [[ "$url" == *"checksums.txt" ]]; then
-    if [[ "${MOCK_FAIL_CHECKSUM_DOWNLOAD:-0}" == "1" ]]; then
-        exit 22
-    fi
-
-    if [[ -n "$output_file" ]]; then
-        printf '%s' "$MOCK_CHECKSUMS_CONTENT" > "$output_file"
-    else
-        printf '%s' "$MOCK_CHECKSUMS_CONTENT"
-    fi
+    [[ "${MOCK_FAIL_CHECKSUM_DOWNLOAD:-0}" == "1" ]] && exit 22
+    [[ "$(basename "$url")" == "$MOCK_CHECKSUMS_NAME" ]] || exit 22
+    printf '%s\n' "$MOCK_CHECKSUMS_CONTENT" > "$output_file"
     exit 0
 fi
 
-if [[ -n "$output_file" ]]; then
-    printf 'mock archive' > "$output_file"
-else
-    printf 'mock archive'
-fi
+[[ "$(basename "$url")" == "$MOCK_ARCHIVE_NAME" ]] || exit 22
+printf 'mock archive' > "$output_file"
 EOF
 
     cat <<'EOF' > "$mock_bin/tar"
 #!/bin/bash
 set -euo pipefail
 
-target_dir=""
+if [[ "${MOCK_TAR_FAIL:-0}" == "1" ]]; then
+    echo "tar: pvtr: Not found in archive" >&2
+    exit 1
+fi
 
+target_dir=""
 while (($#)); do
     case "$1" in
-        -C)
-            target_dir="$2"
-            shift 2
-            ;;
-        *)
-            shift
-            ;;
+        -C) target_dir="$2"; shift 2 ;;
+        *) shift ;;
     esac
 done
 
@@ -136,151 +71,594 @@ mkdir -p "$target_dir"
 printf '#!/bin/sh\nexit 0\n' > "$target_dir/pvtr"
 EOF
 
-    cat <<'EOF' > "$mock_bin/chmod"
-#!/bin/bash
-exit 0
-EOF
-
     cat <<'EOF' > "$mock_bin/sha256sum"
 #!/bin/bash
 printf '%s  %s\n' "${MOCK_ACTUAL_CHECKSUM:-expected-checksum}" "$1"
 EOF
 
-    chmod +x "$mock_bin/uname" "$mock_bin/curl" "$mock_bin/tar" "$mock_bin/chmod" "$mock_bin/sha256sum"
+    chmod +x "$mock_bin/uname" "$mock_bin/curl" "$mock_bin/tar" "$mock_bin/sha256sum"
+}
+
+fail() {
+    echo "FAIL: ${FUNCNAME[1]}: $1"
+    [[ $# -gt 1 ]] && echo "$2"
+    exit 1
 }
 
 assert_contains() {
-    local haystack="$1"
-    local needle="$2"
-
-    if [[ "$haystack" != *"$needle"* ]]; then
-        echo "expected output to contain: $needle"
-        echo "$haystack"
-        exit 1
-    fi
+    [[ "$1" == *"$2"* ]] || fail "expected output to contain: $2" "$1"
 }
 
-run_install() {
-    local work_dir="$1"
-    local install_dir="$2"
+assert_not_contains() {
+    [[ "$1" != *"$2"* ]] || fail "expected output NOT to contain: $2" "$1"
+}
+
+assert_equals() {
+    [[ "$1" == "$2" ]] || fail "expected '$2', got '$1'"
+}
+
+# Evaluates a snippet with install.sh sourced, mocked commands, and an isolated
+# HOME. Extra arguments are visible to the snippet as "$1", "$2", ... Stdin comes
+# from SANDBOX_STDIN, which defaults to /dev/null so a stray prompt cannot hang.
+# Sourcing must not trigger main; that guard is exercised by test_source_does_not_install.
+run_in_sandbox() {
+    local work_dir="$1" snippet="$2"
+    shift 2
 
     local mock_bin="$work_dir/mock-bin"
-    mkdir -p "$mock_bin"
+    mkdir -p "$mock_bin" "$work_dir/home"
     make_mock_commands "$mock_bin"
 
     (
         export PATH="$mock_bin:$PATH"
         export HOME="$work_dir/home"
-        mkdir -p "$HOME"
-        export MOCK_RELEASE_JSON MOCK_CHECKSUMS_CONTENT MOCK_ACTUAL_CHECKSUM MOCK_FAIL_CHECKSUM_DOWNLOAD
-        bash -c 'source "$1"; download_latest_release "$2"' _ "$INSTALL_SCRIPT" "$install_dir"
+        export MOCK_UNAME_S MOCK_UNAME_M MOCK_ARCHIVE_NAME MOCK_CHECKSUMS_CONTENT
+        export MOCK_CHECKSUMS_NAME MOCK_ACTUAL_CHECKSUM MOCK_FAIL_CHECKSUM_DOWNLOAD
+        export MOCK_TAR_FAIL MOCK_URL_LOG SHELL PVTR_VERSION
+        bash -c 'source "$1"; snippet="$2"; shift 2; eval "$snippet"' \
+            _ "$INSTALL_SCRIPT" "$snippet" "$@" < "${SANDBOX_STDIN:-/dev/null}"
     )
 }
 
-test_installs_when_checksum_matches() {
-    local work_dir
-    work_dir="$(mktemp -d)"
-    trap 'rm -rf "$work_dir"' RETURN
-
-    local install_dir="$work_dir/install"
-    MOCK_RELEASE_JSON="$(release_json_with_checksums)"
+# Assigns the caller's `work_dir` and resets mock state. Must be called
+# directly, not in a command substitution, so the assignments survive.
+setup() {
+    MOCK_UNAME_S=Linux
+    MOCK_UNAME_M=x86_64
+    MOCK_ARCHIVE_NAME=pvtr_Linux_x86_64.tar.gz
+    MOCK_CHECKSUMS_NAME=checksums.txt
     MOCK_CHECKSUMS_CONTENT='expected-checksum  pvtr_Linux_x86_64.tar.gz'
-    MOCK_ACTUAL_CHECKSUM='expected-checksum'
+    MOCK_ACTUAL_CHECKSUM=expected-checksum
     MOCK_FAIL_CHECKSUM_DOWNLOAD=0
-
-    local output
-    if ! output=$(run_install "$work_dir" "$install_dir" 2>&1); then
-        echo "expected install to succeed when checksum matches"
-        echo "$output"
-        exit 1
-    fi
-
-    [[ -f "$install_dir/pvtr" ]]
+    MOCK_TAR_FAIL=0
+    SHELL=/bin/bash
+    PVTR_VERSION=""
+    SANDBOX_STDIN=/dev/null
+    work_dir="$(mktemp -d)"
+    MOCK_URL_LOG="$work_dir/urls.txt"
 }
 
-test_fails_when_checksum_asset_missing() {
-    local work_dir
-    work_dir="$(mktemp -d)"
+# --- platform detection ------------------------------------------------------
+
+test_detects_linux_arm64_from_aarch64() {
+    local work_dir; setup
     trap 'rm -rf "$work_dir"' RETURN
 
-    local install_dir="$work_dir/install"
-    MOCK_RELEASE_JSON="$(release_json_without_checksums)"
-    MOCK_CHECKSUMS_CONTENT=''
-    MOCK_ACTUAL_CHECKSUM='expected-checksum'
-    MOCK_FAIL_CHECKSUM_DOWNLOAD=0
+    MOCK_UNAME_M=aarch64
+    assert_equals "$(run_in_sandbox "$work_dir" 'detect_platform; echo "$PLATFORM"')" "Linux_arm64"
+}
+
+test_detects_universal_darwin_archive() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    # Darwin archives are universal, so an unrecognised arch must not matter.
+    MOCK_UNAME_S=Darwin
+    MOCK_UNAME_M=some_future_arch
+    assert_equals "$(run_in_sandbox "$work_dir" 'detect_platform; echo "$PLATFORM"')" "Darwin_all"
+}
+
+test_rejects_unsupported_os() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_UNAME_S=MINGW64_NT-10.0
+    local output
+    output="$(run_in_sandbox "$work_dir" 'detect_platform' 2>&1)" \
+        && fail "expected detect_platform to reject an unsupported OS"
+    assert_contains "$output" "Unsupported OS"
+}
+
+test_rejects_unsupported_arch() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_UNAME_M=riscv64
+    local output
+    output="$(run_in_sandbox "$work_dir" 'detect_platform' 2>&1)" \
+        && fail "expected detect_platform to reject an unsupported architecture"
+    assert_contains "$output" "Unsupported architecture"
+}
+
+# detect_platform reports failure through `fail`, which exits. If it were called
+# in a command substitution that exit would unwind only the subshell, and main
+# would carry on and download with an empty platform.
+test_unsupported_platform_aborts_main() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_UNAME_S=MINGW64_NT-10.0
+    local output
+    output="$(run_in_sandbox "$work_dir" 'main -p "$1"' "$work_dir/install" 2>&1)" \
+        && fail "expected main to abort on an unsupported platform"
+    assert_contains "$output" "Unsupported OS"
+    assert_not_contains "$output" "Failed to download"
+    [[ ! -e "$MOCK_URL_LOG" ]] || fail "must not attempt a download after platform detection fails"
+}
+
+# --- prerequisites -----------------------------------------------------------
+
+# A function named `command` shadows the builtin, which lets these tests
+# simulate a missing tool without rebuilding PATH.
+test_requires_a_checksum_tool() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
 
     local output
-    if output=$(run_install "$work_dir" "$install_dir" 2>&1); then
-        echo "expected install to fail when checksum asset is missing"
-        exit 1
-    fi
+    output="$(run_in_sandbox "$work_dir" \
+        'command() { [[ "$2" == sha256sum || "$2" == shasum ]] && return 1; builtin command "$@"; }
+         ensure_prerequisites' 2>&1)" \
+        && fail "expected ensure_prerequisites to require a checksum tool"
+    assert_contains "$output" "Neither sha256sum nor shasum is available"
+}
 
-    assert_contains "$output" "No checksums file found in release assets"
+test_requires_curl() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" \
+        'command() { [[ "$2" == curl ]] && return 1; builtin command "$@"; }
+         ensure_prerequisites' 2>&1)" \
+        && fail "expected ensure_prerequisites to require curl"
+    assert_contains "$output" "curl is required"
+}
+
+test_prerequisites_pass_on_a_normal_system() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'ensure_prerequisites' \
+        || fail "expected ensure_prerequisites to pass on this machine"
+}
+
+# Missing tools must be reported before anything is fetched.
+test_missing_tool_aborts_before_download() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" \
+        'command() { [[ "$2" == sha256sum || "$2" == shasum ]] && return 1; builtin command "$@"; }
+         main -p "$1"' "$work_dir/install" 2>&1)" \
+        && fail "expected main to abort when no checksum tool is available"
+    assert_contains "$output" "Neither sha256sum nor shasum is available"
+    assert_not_contains "$output" "Checksum mismatch"
+    [[ ! -e "$MOCK_URL_LOG" ]] || fail "must not download before checking prerequisites"
+}
+
+# --- download and verification ----------------------------------------------
+
+test_installs_when_checksum_matches() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        || fail "expected install to succeed when checksum matches" "$output"
+    [[ -f "$work_dir/install/pvtr" ]] || fail "expected pvtr to be installed"
+    [[ -x "$work_dir/install/pvtr" ]] || fail "expected pvtr to be executable"
+}
+
+test_falls_back_to_legacy_archive_name() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_ARCHIVE_NAME=privateer_Linux_x86_64.tar.gz
+    MOCK_CHECKSUMS_CONTENT='expected-checksum  privateer_Linux_x86_64.tar.gz'
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        || fail "expected fallback to legacy privateer_* archive name" "$output"
+    assert_contains "$output" "privateer_Linux_x86_64.tar.gz"
+}
+
+# v0.21.0 and earlier named the checksums file privateer_<version>_checksums.txt.
+test_falls_back_to_legacy_checksums_name() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_ARCHIVE_NAME=privateer_Linux_x86_64.tar.gz
+    MOCK_CHECKSUMS_NAME=privateer_0.21.0_checksums.txt
+    MOCK_CHECKSUMS_CONTENT='expected-checksum  privateer_Linux_x86_64.tar.gz'
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/download/v0.21.0 v0.21.0 2>&1)" \
+        || fail "expected fallback to the legacy checksums file name" "$output"
+    assert_contains "$output" "Verifying against privateer_0.21.0_checksums.txt"
+    [[ -f "$work_dir/install/pvtr" ]] || fail "expected pvtr to be installed"
+}
+
+# The legacy name embeds a version number, so it is unknowable for "latest" and
+# must not be probed there.
+test_latest_does_not_probe_legacy_checksums_name() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest > /dev/null
+    assert_not_contains "$(cat "$MOCK_URL_LOG")" "privateer_latest_checksums.txt"
+}
+
+test_fails_when_no_archive_found() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_ARCHIVE_NAME=pvtr_Linux_riscv64.tar.gz
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        && fail "expected install to fail when no archive matches"
+    assert_contains "$output" "Failed to download a release archive"
 }
 
 test_fails_when_checksum_download_fails() {
-    local work_dir
-    work_dir="$(mktemp -d)"
+    local work_dir; setup
     trap 'rm -rf "$work_dir"' RETURN
 
-    local install_dir="$work_dir/install"
-    MOCK_RELEASE_JSON="$(release_json_with_checksums)"
-    MOCK_CHECKSUMS_CONTENT='expected-checksum  pvtr_Linux_x86_64.tar.gz'
-    MOCK_ACTUAL_CHECKSUM='expected-checksum'
     MOCK_FAIL_CHECKSUM_DOWNLOAD=1
 
     local output
-    if output=$(run_install "$work_dir" "$install_dir" 2>&1); then
-        echo "expected install to fail when checksum download fails"
-        exit 1
-    fi
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        && fail "expected install to fail when checksums download fails"
+    assert_contains "$output" "Failed to download a checksums file"
+    [[ ! -f "$work_dir/install/pvtr" ]] || fail "must not install an unverified binary"
+}
 
-    assert_contains "$output" "Failed to download checksums file"
+test_fails_when_archive_missing_from_checksums() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_CHECKSUMS_CONTENT='expected-checksum  some_other_archive.tar.gz'
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        && fail "expected install to fail when the archive has no checksum entry"
+    assert_contains "$output" "No entry for"
+    [[ ! -f "$work_dir/install/pvtr" ]] || fail "must not install an unverified binary"
 }
 
 test_fails_when_checksum_mismatches() {
-    local work_dir
-    work_dir="$(mktemp -d)"
+    local work_dir; setup
     trap 'rm -rf "$work_dir"' RETURN
 
-    local install_dir="$work_dir/install"
-    MOCK_RELEASE_JSON="$(release_json_with_checksums)"
-    MOCK_CHECKSUMS_CONTENT='expected-checksum  pvtr_Linux_x86_64.tar.gz'
-    MOCK_ACTUAL_CHECKSUM='different-checksum'
-    MOCK_FAIL_CHECKSUM_DOWNLOAD=0
+    MOCK_ACTUAL_CHECKSUM=different-checksum
 
     local output
-    if output=$(run_install "$work_dir" "$install_dir" 2>&1); then
-        echo "expected install to fail when checksum mismatches"
-        exit 1
-    fi
-
-    assert_contains "$output" "CHECKSUM MISMATCH"
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        && fail "expected install to fail when checksum mismatches"
+    assert_contains "$output" "Checksum mismatch"
+    [[ ! -f "$work_dir/install/pvtr" ]] || fail "must not install a tampered binary"
 }
 
-test_installs_when_release_json_is_compact() {
-    local work_dir
-    work_dir="$(mktemp -d)"
+# The binary is staged and renamed into place, so a failure part-way through
+# must not leave anything at the install path.
+test_leaves_no_binary_when_extraction_fails() {
+    local work_dir; setup
     trap 'rm -rf "$work_dir"' RETURN
 
-    local install_dir="$work_dir/install"
-    MOCK_RELEASE_JSON="$(release_json_with_checksums_compact)"
-    MOCK_CHECKSUMS_CONTENT='expected-checksum  pvtr_Linux_x86_64.tar.gz'
-    MOCK_ACTUAL_CHECKSUM='expected-checksum'
-    MOCK_FAIL_CHECKSUM_DOWNLOAD=0
+    MOCK_TAR_FAIL=1
 
     local output
-    if ! output=$(run_install "$work_dir" "$install_dir" 2>&1); then
-        echo "expected install to succeed when release JSON is compact"
-        echo "$output"
-        exit 1
-    fi
-
-    [[ -f "$install_dir/pvtr" ]]
+    output="$(run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest 2>&1)" \
+        && fail "expected install to fail when extraction fails"
+    assert_contains "$output" "does not contain a pvtr binary"
+    [[ ! -e "$work_dir/install/pvtr" ]] || fail "must not leave a partial binary behind"
 }
 
+test_removes_staged_file_on_success() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'download_release "$1" "$2" "$3" "$4"' \
+        "$work_dir/install" Linux_x86_64 https://example.test/latest/download latest > /dev/null
+    local leftovers
+    leftovers="$(find "$work_dir/install" -name '.pvtr.download.*' | wc -l | tr -d ' ')"
+    assert_equals "$leftovers" "0"
+}
+
+# --- version selection -------------------------------------------------------
+
+test_defaults_to_latest_release() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    assert_equals "$(run_in_sandbox "$work_dir" 'release_base_url latest')" \
+        "https://github.com/privateerproj/privateer/releases/latest/download"
+}
+
+test_pins_requested_version() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    assert_equals "$(run_in_sandbox "$work_dir" 'release_base_url v0.22.0')" \
+        "https://github.com/privateerproj/privateer/releases/download/v0.22.0"
+}
+
+test_normalizes_version_without_v_prefix() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    assert_equals "$(run_in_sandbox "$work_dir" 'release_base_url 0.22.0')" \
+        "https://github.com/privateerproj/privateer/releases/download/v0.22.0"
+}
+
+test_version_flag_reaches_the_download_url() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'main -p "$1" -v v0.22.0 -y' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$MOCK_URL_LOG")" "/releases/download/v0.22.0/pvtr_Linux_x86_64.tar.gz"
+}
+
+test_version_env_var_is_honoured() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    PVTR_VERSION=v0.21.0
+    run_in_sandbox "$work_dir" 'main -p "$1" -y' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$MOCK_URL_LOG")" "/releases/download/v0.21.0/"
+}
+
+test_version_flag_beats_env_var() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    PVTR_VERSION=v0.21.0
+    run_in_sandbox "$work_dir" 'main -p "$1" -v v0.22.0 -y' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$MOCK_URL_LOG")" "/releases/download/v0.22.0/"
+    assert_not_contains "$(cat "$MOCK_URL_LOG")" "v0.21.0"
+}
+
+# --- install directory -------------------------------------------------------
+
+test_fails_before_downloading_when_dir_not_writable() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    if [[ "$EUID" -eq 0 ]]; then
+        echo "SKIP: ${FUNCNAME[0]} (running as root)"
+        return
+    fi
+
+    local readonly_dir="$work_dir/readonly"
+    mkdir -p "$readonly_dir"
+    chmod 555 "$readonly_dir"
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'main -p "$1"' "$readonly_dir/bin" 2>&1)" \
+        && fail "expected main to fail when the install dir is not writable"
+    assert_contains "$output" "not writable"
+    [[ ! -e "$MOCK_URL_LOG" ]] || fail "must not download before checking writability"
+    chmod 755 "$readonly_dir"
+}
+
+test_relative_install_dir_is_made_absolute() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(cd "$work_dir" && run_in_sandbox "$work_dir" 'main -p "$1" -y' relative-bin 2>&1)"
+    assert_contains "$output" "Installed $work_dir/relative-bin/pvtr"
+    assert_contains "$(cat "$work_dir/home/.bashrc")" "export PATH=\"$work_dir/relative-bin:\$PATH\""
+}
+
+# A './' left in the path would leak into the PATH line printed to the user.
+test_install_dir_is_normalized() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    assert_equals "$(run_in_sandbox "$work_dir" 'abspath ./e2e/bin')" "$PWD/e2e/bin"
+    assert_equals "$(run_in_sandbox "$work_dir" 'abspath /opt//pvtr/./bin/')" "/opt/pvtr/bin"
+    assert_equals "$(run_in_sandbox "$work_dir" 'abspath /')" "/"
+    assert_equals "$(run_in_sandbox "$work_dir" 'abspath /already/absolute')" "/already/absolute"
+}
+
+# --- PATH handling -----------------------------------------------------------
+
+test_path_is_not_modified_without_consent() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'update_path "$1" false' "$work_dir/install" 2>&1)"
+    assert_contains "$output" "add $work_dir/install to your PATH"
+    [[ ! -f "$work_dir/home/.bashrc" ]] || fail "must not edit shell config without consent"
+}
+
+test_path_is_modified_with_consent() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$work_dir/home/.bashrc")" "export PATH=\"$work_dir/install:\$PATH\""
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" 2>&1)"
+    assert_contains "$output" "already references"
+    assert_equals "$(grep -c "$work_dir/install" "$work_dir/home/.bashrc")" "1"
+}
+
+test_prompt_accepts_yes() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    mkdir -p "$work_dir/home"
+    printf 'y\n' > "$work_dir/reply"
+    SANDBOX_STDIN="$work_dir/reply"
+
+    run_in_sandbox "$work_dir" 'is_interactive() { return 0; }; update_path "$1" false' \
+        "$work_dir/install" > /dev/null 2>&1
+    assert_contains "$(cat "$work_dir/home/.bashrc")" "export PATH=\"$work_dir/install:\$PATH\""
+}
+
+# Ctrl-D makes `read` return non-zero, which under `set -e` would otherwise
+# abort the script after the binary is already installed.
+test_eof_at_prompt_declines_without_aborting() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" \
+        'is_interactive() { return 0; }; update_path "$1" false; echo REACHED_END' \
+        "$work_dir/install" 2>&1)" \
+        || fail "expected EOF at the prompt to decline, not abort" "$output"
+    assert_contains "$output" "REACHED_END"
+    assert_contains "$output" "add $work_dir/install to your PATH"
+    [[ ! -f "$work_dir/home/.bashrc" ]] || fail "must not edit shell config on EOF"
+}
+
+# macOS terminals start login shells, which read .bash_profile, not .bashrc.
+test_bash_on_macos_uses_bash_profile() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    MOCK_UNAME_S=Darwin
+    run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$work_dir/home/.bash_profile")" "export PATH=\"$work_dir/install:\$PATH\""
+    [[ ! -f "$work_dir/home/.bashrc" ]] || fail "must not write .bashrc on macOS"
+}
+
+test_bash_on_linux_uses_bashrc() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$work_dir/home/.bashrc")" "export PATH=\"$work_dir/install:\$PATH\""
+    [[ ! -f "$work_dir/home/.bash_profile" ]] || fail "must not write .bash_profile on Linux"
+}
+
+test_fish_gets_native_path_syntax() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    SHELL=/usr/local/bin/fish
+    run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" > /dev/null
+    assert_contains "$(cat "$work_dir/home/.config/fish/config.fish")" "fish_add_path \"$work_dir/install\""
+}
+
+test_commented_out_path_line_is_not_treated_as_configured() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    mkdir -p "$work_dir/home"
+    printf '# export PATH="%s:$PATH"\n' "$work_dir/install" > "$work_dir/home/.bashrc"
+
+    run_in_sandbox "$work_dir" 'update_path "$1" true' "$work_dir/install" > /dev/null
+    assert_equals "$(grep -c "^export PATH" "$work_dir/home/.bashrc")" "1"
+}
+
+# --- argument handling -------------------------------------------------------
+
+test_rejects_unexpected_arguments() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'main -y stray-argument' 2>&1)" \
+        && fail "expected main to reject a stray positional argument"
+    assert_contains "$output" "unexpected argument: stray-argument"
+}
+
+test_rejects_unknown_flag() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" 'main -Z' 2>&1)" \
+        && fail "expected main to reject an unknown flag"
+    assert_contains "$output" "Usage: install.sh"
+}
+
+# --- invocation modes --------------------------------------------------------
+
+# The README installs via `bash -c "$(curl ...)"`, where BASH_SOURCE is unset.
+test_runs_when_piped_to_bash() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(/bin/bash -c "$(cat "$INSTALL_SCRIPT")" -- -h < /dev/null)" \
+        || fail "expected piped invocation to run main"
+    assert_contains "$output" "Usage: install.sh"
+}
+
+test_source_does_not_install() {
+    local work_dir; setup
+    trap 'rm -rf "$work_dir"' RETURN
+
+    local output
+    output="$(run_in_sandbox "$work_dir" ':' 2>&1)"
+    assert_equals "$output" ""
+}
+
+test_detects_linux_arm64_from_aarch64
+test_detects_universal_darwin_archive
+test_rejects_unsupported_os
+test_rejects_unsupported_arch
+test_unsupported_platform_aborts_main
+test_requires_a_checksum_tool
+test_requires_curl
+test_prerequisites_pass_on_a_normal_system
+test_missing_tool_aborts_before_download
 test_installs_when_checksum_matches
-test_fails_when_checksum_asset_missing
+test_falls_back_to_legacy_archive_name
+test_falls_back_to_legacy_checksums_name
+test_latest_does_not_probe_legacy_checksums_name
+test_fails_when_no_archive_found
 test_fails_when_checksum_download_fails
+test_fails_when_archive_missing_from_checksums
 test_fails_when_checksum_mismatches
-test_installs_when_release_json_is_compact
+test_leaves_no_binary_when_extraction_fails
+test_removes_staged_file_on_success
+test_defaults_to_latest_release
+test_pins_requested_version
+test_normalizes_version_without_v_prefix
+test_version_flag_reaches_the_download_url
+test_version_env_var_is_honoured
+test_version_flag_beats_env_var
+test_fails_before_downloading_when_dir_not_writable
+test_relative_install_dir_is_made_absolute
+test_install_dir_is_normalized
+test_path_is_not_modified_without_consent
+test_path_is_modified_with_consent
+test_prompt_accepts_yes
+test_eof_at_prompt_declines_without_aborting
+test_bash_on_macos_uses_bash_profile
+test_bash_on_linux_uses_bashrc
+test_fish_gets_native_path_syntax
+test_commented_out_path_line_is_not_treated_as_configured
+test_rejects_unexpected_arguments
+test_rejects_unknown_flag
+test_runs_when_piped_to_bash
+test_source_does_not_install
+
+echo "All install.sh tests passed."


### PR DESCRIPTION
This is always a tough one, since it's outside of my wheelhouse. I was hitting some hard-to-diagnose bugs using the installer, so I asked Claude to help revise the logic to follow best practices from other OSS projects.

---


## 🤖 Research behind these changes

A record of what evidence informed each decision, and — just as importantly — which claims rest on evidence gathered here versus on background knowledge that was not independently verified.

### 1. Configuration and source read in-repo

| Source | What it settled |
| --- | --- |
| `.goreleaser.yaml` | `universal_binaries: replace: true` means Darwin ships a single `Darwin_all` archive, so **arch detection is dead code on macOS**. `format_overrides` proves Windows ships `.zip`, so the previous script's `tar xf` could never have worked there. `checksum.name_template: "checksums.txt"` fixes the primary checksums candidate. |
| `.github/workflows/release.yaml` | `create-attestation: true` — the project already publishes GitHub build provenance. This turns "should the installer verify signatures?" from speculation into an already-available capability. |
| `cmd/cli.go:98–107` | `~/.privateer/bin` is the **plugin binaries directory** the CLI reads at runtime, corroborated by `README.md:79`. |
| `Makefile:31,33` | `test/install_test.sh` is wired into `make test`, so the suite had to stay green and self-contained. |
| `README.md` | The docs advertise `-p /usr/local/bin`, which needs root on most systems — the motivation for the pre-flight writability check. |

The `cmd/cli.go` finding most changed the outcome. The obvious fix for the whole `PATH` problem is "install somewhere already on `PATH`", and that option was **eliminated** by discovering the default install directory is load-bearing for plugin discovery.

### 2. Live release artifacts

Published releases were queried directly rather than inferring behaviour from the GoReleaser config:

```
gh release view v0.22.0 → checksums.txt,                  privateer_*.tar.gz, privateer_Windows_*.zip
gh release view v0.21.0 → privateer_0.21.0_checksums.txt, privateer_*.tar.gz, privateer_Windows_*.zip
```

- **v0.22.0 is still `privateer_*`.** The rename in `73d087e` has not shipped. The legacy-prefix fallback is load-bearing right now, but not for the reason originally documented: `latest/download` only resolves inside the newest release, so it could never have reached older releases — it bridges the pre-release window. The comment was corrected accordingly.
- **The checksums filename also changed** between releases. Nothing in the repository records this; the current `.goreleaser.yaml` describes only today's format. Only the artifacts show it.
- `privateer_0.21.0_checksums.txt` was then fetched directly to confirm its two-column `<sha>  <name>` layout was unchanged, establishing that a *name* fallback was sufficient and no parser change was needed.

### 3. Empirical shell experiments

Three throwaway scripts. Each changed the outcome, including one that prevented a change.

**A — `exit` inside `$( )` does not abort the caller.**

```
ERROR: unsupported
g ran with platform=[]     ← execution continued
exit=0
```

This escalated `detect_platform` from a code smell to a confirmed bug, and later drove finding a second instance in `sha256`, where the symptom would have been a misleading "Checksum mismatch" on a machine with no SHA tool.

**B — `set -e` with a trailing `&&` list is safe.** `[[ … ]] && consent=true` was suspected of being a latent exit. Bash exempts a command *before* the final `&&`, so it is not. **This experiment prevented a change**; without it, correct code would have been "fixed" and a non-existent bug reported. The only genuine `set -e` hazard was `read` returning non-zero at EOF.

**C — process-spawn microbenchmark**, run after the test suite blew a 120s timeout:

```
10x bash -c 'true'  → 4.4s   (440ms each)
10x mktemp -d       → 8.8s   (877ms each)
```

Combined with per-test instrumentation showing a flat ~1s per sandbox call and no outlier, this identified the slowness as **environmental to the development machine**, not a property of the suite. On normal CI these primitives are 1–2ms.

### 4. End-to-end runs against production GitHub

Mocked tests validate logic; they cannot validate assumptions about a remote service. **Two defects survived a fully green suite** and were caught only here:

- **Version pinning was half-broken.** `-v 0.21.0` downloaded the archive, then 404'd on `checksums.txt`. The unit tests passed because the mock served *any* URL ending in `checksums.txt` — it encoded the assumption rather than reality. Fixing it required adding `MOCK_CHECKSUMS_NAME` so the test was *capable* of failing.
- **`abspath` leaked `./`** into the `PATH` line printed to users (`.../scratchpad/./e2e/bin`). Invisible to tests using absolute paths.

Final verification ran `latest`, `-v v0.22.0`, `-v 0.21.0`, and `PVTR_VERSION` against real releases, confirming the installed binary reported the pinned version in each case, plus both `PATH` modes under a synthetic `HOME` so no real dotfiles were touched.

### 5. Background knowledge applied — not verified here

Stated plainly, because it is the weakest evidence in the set and the `PATH` default rests partly on it:

- **Installer conventions** (rustup, uv, bun, deno modifying `PATH` by default with an opt-out) were recalled from model training, **not verified during this work**. Those installers' sources and docs were not fetched. This was the main external justification for making the `PATH` edit the default, so it is worth confirming independently if that decision is contested.
- **macOS login shells read `.bash_profile`, not `.bashrc`** — standard bash startup semantics, reasoned from rather than tested against a fresh login shell.
- `rename(2)` atomicity within a filesystem; `curl --retry` not retrying 4xx; `~/.profile` as the generic POSIX fallback.

Everything in sections 1–4 was verified directly. Section 5 was not.

### 6. Research that produced a reverted change

When the suite exceeded the tool timeout, mock generation was hoisted out of `run_in_sandbox` on the theory that macOS was re-checking freshly-created executables. **Measurement disproved it** — no improvement. The change was reverted rather than kept on a false rationale; it bought nothing measurable and traded away per-test mock isolation. The real cause was 3C.

### 7. Known gaps

- **`shellcheck` was not available** in the development environment; the scripts have had `bash -n` plus the test suite only. Worth adding to CI.
- **Windows/MSYS is untested and unhandled.** The release publishes three `Windows_*.zip` assets the installer does not support; it now fails with a clear pointer to the releases page rather than feeding a `.zip` to `tar`. Whether to support it properly is an open scope decision.
- **Attestation verification is unimplemented.** The checksum proves integrity against a same-origin file, not authenticity, despite section 1 showing provenance is already published.
- **The `~/.profile` fallback is covered by unit tests only**, not against a real ksh/dash login shell.
